### PR TITLE
feat: disable bench ci steps on scroll branch

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   merge_group:
   push:
-    branches: [main, scroll]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This action [is failing](https://github.com/scroll-tech/reth/actions/runs/11145444014/job/30975067251) with

```
    Finished `profiling` profile [optimized + debuginfo] target(s) in 1m 58s
     Running benches/iai.rs (target/profiling/deps/iai-068d5ba708ef06ee)
iai_callgrind_runner: Error: Failed to decode configuration
error: bench failed, to rerun pass `-p reth-db --bench iai`

Caused by:
  process didn't exit successfully: `/home/runner/work/reth/reth/target/profiling/deps/iai-068d5ba708ef06ee --save-baseline=base --bench` (exit status: 1)
Error: Process completed with exit code 1.
```

in the "save baseline" step.

I traced this error back to [here](https://github.com/iai-callgrind/iai-callgrind/blob/25f9270b56d3e94ef05ca027c9cc2c3e8d83a8aa/iai-callgrind-runner/src/runner/mod.rs#L171) and [here](https://github.com/AbnerZheng/reth/blob/main/crates/storage/db/benches/iai.rs), but I have not been able to fix it yet. Since we probably won't change this db serialization par, it is fine to disable this action.