### PR TITLE
feat: introduce `StateCommitment` in `StateProviders`

### DIFF
--- a/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/in_memory_merkle.rs
@@ -22,8 +22,8 @@ use reth_node_ethereum::EthExecutorProvider;
 use reth_primitives::BlockHashOrNumber;
 use reth_provider::{
     writer::UnifiedStorageWriter, AccountExtReader, ChainSpecProvider, HashingWriter,
-    HeaderProvider, LatestStateProviderRef, OriginalValuesKnown, ProviderFactory,
-    StageCheckpointReader, StateWriter, StaticFileProviderFactory, StorageReader,
+    HeaderProvider, OriginalValuesKnown, ProviderFactory, StageCheckpointReader, StateWriter,
+    StorageReader, ToLatestStateProviderRef,
 };
 use reth_revm::database::StateProviderDatabase;
 use reth_stages::StageId;
@@ -131,10 +131,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
             )
             .await?;
 
-        let db = StateProviderDatabase::new(LatestStateProviderRef::new(
-            provider.tx_ref(),
-            provider_factory.static_file_provider(),
-        ));
+        let db = StateProviderDatabase::new(provider.latest());
 
         let executor = EthExecutorProvider::ethereum(provider_factory.chain_spec()).executor(db);
 

--- a/bin/reth/src/commands/debug_cmd/merkle.rs
+++ b/bin/reth/src/commands/debug_cmd/merkle.rs
@@ -21,8 +21,8 @@ use reth_node_ethereum::EthExecutorProvider;
 use reth_primitives::BlockHashOrNumber;
 use reth_provider::{
     writer::UnifiedStorageWriter, BlockNumReader, BlockWriter, ChainSpecProvider,
-    DatabaseProviderFactory, HeaderProvider, LatestStateProviderRef, OriginalValuesKnown,
-    ProviderError, ProviderFactory, StateWriter, StaticFileProviderFactory,
+    DatabaseProviderFactory, HeaderProvider, OriginalValuesKnown, ProviderError, ProviderFactory,
+    StateWriter, ToLatestStateProviderRef,
 };
 use reth_revm::database::StateProviderDatabase;
 use reth_stages::{
@@ -152,12 +152,8 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>> Command<C> {
             provider_rw.insert_block(sealed_block.clone())?;
 
             td += sealed_block.difficulty;
-            let mut executor = executor_provider.batch_executor(StateProviderDatabase::new(
-                LatestStateProviderRef::new(
-                    provider_rw.tx_ref(),
-                    provider_rw.static_file_provider().clone(),
-                ),
-            ));
+            let mut executor =
+                executor_provider.batch_executor(StateProviderDatabase::new(provider_rw.latest()));
             executor.execute_and_verify_one((&sealed_block.clone().unseal(), td).into())?;
             let execution_outcome = executor.finalize();
 

--- a/crates/stages/stages/benches/criterion.rs
+++ b/crates/stages/stages/benches/criterion.rs
@@ -14,6 +14,7 @@ use reth_stages::{
     StageCheckpoint,
 };
 use reth_stages_api::{ExecInput, Stage, StageExt, UnwindInput};
+use reth_trie_db::MerklePatriciaTrie;
 use std::ops::RangeInclusive;
 use tokio::runtime::Runtime;
 
@@ -148,7 +149,14 @@ fn measure_stage<F, S>(
     block_interval: RangeInclusive<BlockNumber>,
     label: String,
 ) where
-    S: Clone + Stage<DatabaseProvider<<TempDatabase<DatabaseEnv> as Database>::TXMut, ChainSpec>>,
+    S: Clone
+        + Stage<
+            DatabaseProvider<
+                <TempDatabase<DatabaseEnv> as Database>::TXMut,
+                ChainSpec,
+                MerklePatriciaTrie,
+            >,
+        >,
     F: Fn(S, &TestStageDB, StageRange),
 {
     let stage_range = (

--- a/crates/stages/stages/benches/setup/mod.rs
+++ b/crates/stages/stages/benches/setup/mod.rs
@@ -26,12 +26,19 @@ mod constants;
 mod account_hashing;
 pub use account_hashing::*;
 use reth_stages_api::{ExecInput, Stage, UnwindInput};
-use reth_trie_db::DatabaseStateRoot;
+use reth_trie_db::{DatabaseStateRoot, MerklePatriciaTrie};
 
 pub(crate) type StageRange = (ExecInput, UnwindInput);
 
 pub(crate) fn stage_unwind<
-    S: Clone + Stage<DatabaseProvider<<TempDatabase<DatabaseEnv> as Database>::TXMut, ChainSpec>>,
+    S: Clone
+        + Stage<
+            DatabaseProvider<
+                <TempDatabase<DatabaseEnv> as Database>::TXMut,
+                ChainSpec,
+                MerklePatriciaTrie,
+            >,
+        >,
 >(
     stage: S,
     db: &TestStageDB,
@@ -63,7 +70,14 @@ pub(crate) fn stage_unwind<
 
 pub(crate) fn unwind_hashes<S>(stage: S, db: &TestStageDB, range: StageRange)
 where
-    S: Clone + Stage<DatabaseProvider<<TempDatabase<DatabaseEnv> as Database>::TXMut, ChainSpec>>,
+    S: Clone
+        + Stage<
+            DatabaseProvider<
+                <TempDatabase<DatabaseEnv> as Database>::TXMut,
+                ChainSpec,
+                MerklePatriciaTrie,
+            >,
+        >,
 {
     let (input, unwind) = range;
 

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -15,8 +15,8 @@ use reth_primitives_traits::format_gas_throughput;
 use reth_provider::{
     providers::{StaticFileProvider, StaticFileProviderRWRefMut, StaticFileWriter},
     writer::UnifiedStorageWriter,
-    BlockReader, DBProvider, HeaderProvider, LatestStateProviderRef, OriginalValuesKnown,
-    ProviderError, StateChangeWriter, StateWriter, StaticFileProviderFactory, StatsReader,
+    BlockReader, DBProvider, HeaderProvider, OriginalValuesKnown, ProviderError, StateChangeWriter,
+    StateWriter, StaticFileProviderFactory, StatsReader, ToLatestStateProviderRef,
     TransactionVariant,
 };
 use reth_prune_types::PruneModes;
@@ -45,8 +45,9 @@ use tracing::*;
 /// - [`tables::BlockBodyIndices`] to get tx number
 /// - [`tables::Transactions`] to execute
 ///
-/// For state access [`LatestStateProviderRef`] provides us latest state and history state
-/// For latest most recent state [`LatestStateProviderRef`] would need (Used for execution Stage):
+/// For state access [`reth_provider::LatestStateProviderRef`] provides us latest state and history
+/// state For latest most recent state [`reth_provider::LatestStateProviderRef`] would need (Used
+/// for execution Stage):
 /// - [`tables::PlainAccountState`]
 /// - [`tables::Bytecodes`]
 /// - [`tables::PlainStorageState`]
@@ -174,8 +175,12 @@ impl<E> ExecutionStage<E> {
 impl<E, Provider> Stage<Provider> for ExecutionStage<E>
 where
     E: BlockExecutorProvider,
-    Provider:
-        DBProvider + BlockReader + StaticFileProviderFactory + StatsReader + StateChangeWriter,
+    Provider: DBProvider
+        + BlockReader
+        + StaticFileProviderFactory
+        + StatsReader
+        + StateChangeWriter
+        + ToLatestStateProviderRef,
     for<'a> UnifiedStorageWriter<'a, Provider, StaticFileProviderRWRefMut<'a>>: StateWriter,
 {
     /// Return the id of the stage
@@ -219,10 +224,7 @@ where
             None
         };
 
-        let db = StateProviderDatabase(LatestStateProviderRef::new(
-            provider.tx_ref(),
-            provider.static_file_provider(),
-        ));
+        let db = StateProviderDatabase(provider.latest());
         let mut executor = self.executor_provider.batch_executor(db);
         executor.set_tip(max_block);
         executor.set_prune_modes(prune_modes);

--- a/crates/stages/stages/src/stages/hashing_account.rs
+++ b/crates/stages/stages/src/stages/hashing_account.rs
@@ -61,8 +61,9 @@ impl AccountHashingStage {
     pub fn seed<
         Tx: DbTx + DbTxMut + 'static,
         Spec: Send + Sync + 'static + reth_chainspec::EthereumHardforks,
+        SC: Send + Sync + 'static,
     >(
-        provider: &reth_provider::DatabaseProvider<Tx, Spec>,
+        provider: &reth_provider::DatabaseProvider<Tx, Spec, SC>,
         opts: SeedOpts,
     ) -> Result<Vec<(alloy_primitives::Address, reth_primitives::Account)>, StageError> {
         use alloy_primitives::U256;

--- a/crates/stages/stages/src/test_utils/runner.rs
+++ b/crates/stages/stages/src/test_utils/runner.rs
@@ -6,6 +6,7 @@ use reth_stages_api::{
     ExecInput, ExecOutput, Stage, StageError, StageExt, UnwindInput, UnwindOutput,
 };
 use reth_storage_errors::db::DatabaseError;
+use reth_trie_db::MerklePatriciaTrie;
 use tokio::sync::oneshot;
 
 #[derive(thiserror::Error, Debug)]
@@ -20,8 +21,13 @@ pub(crate) enum TestRunnerError {
 
 /// A generic test runner for stages.
 pub(crate) trait StageTestRunner {
-    type S: Stage<DatabaseProvider<<TempDatabase<DatabaseEnv> as Database>::TXMut, ChainSpec>>
-        + 'static;
+    type S: Stage<
+            DatabaseProvider<
+                <TempDatabase<DatabaseEnv> as Database>::TXMut,
+                ChainSpec,
+                MerklePatriciaTrie,
+            >,
+        > + 'static;
 
     /// Return a reference to the database.
     fn db(&self) -> &TestStageDB;

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -302,7 +302,7 @@ impl<N: ProviderNodeTypes> BlockchainProvider2<N> {
     ) -> ProviderResult<Vec<T>>
     where
         F: FnOnce(
-            &DatabaseProviderRO<N::DB, N::ChainSpec>,
+            &DatabaseProviderRO<N::DB, N::ChainSpec, N::StateCommitment>,
             RangeInclusive<BlockNumber>,
             &mut P,
         ) -> ProviderResult<Vec<T>>,
@@ -418,7 +418,7 @@ impl<N: ProviderNodeTypes> BlockchainProvider2<N> {
     ) -> ProviderResult<Vec<R>>
     where
         S: FnOnce(
-            DatabaseProviderRO<N::DB, N::ChainSpec>,
+            DatabaseProviderRO<N::DB, N::ChainSpec, N::StateCommitment>,
             RangeInclusive<TxNumber>,
         ) -> ProviderResult<Vec<R>>,
         M: Fn(RangeInclusive<usize>, Arc<BlockState>) -> ProviderResult<Vec<R>>,
@@ -516,7 +516,9 @@ impl<N: ProviderNodeTypes> BlockchainProvider2<N> {
         fetch_from_block_state: M,
     ) -> ProviderResult<Option<R>>
     where
-        S: FnOnce(DatabaseProviderRO<N::DB, N::ChainSpec>) -> ProviderResult<Option<R>>,
+        S: FnOnce(
+            DatabaseProviderRO<N::DB, N::ChainSpec, N::StateCommitment>,
+        ) -> ProviderResult<Option<R>>,
         M: Fn(usize, TxNumber, Arc<BlockState>) -> ProviderResult<Option<R>>,
     {
         // Order of instantiation matters. More information on:
@@ -585,7 +587,7 @@ impl<N: ProviderNodeTypes> BlockchainProvider2<N> {
         fetch_from_block_state: M,
     ) -> ProviderResult<R>
     where
-        S: FnOnce(DatabaseProviderRO<N::DB, N::ChainSpec>) -> ProviderResult<R>,
+        S: FnOnce(DatabaseProviderRO<N::DB, N::ChainSpec, N::StateCommitment>) -> ProviderResult<R>,
         M: Fn(Arc<BlockState>) -> ProviderResult<R>,
     {
         let block_state = match id {

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -24,9 +24,9 @@ use reth_trie::{
 };
 use reth_trie_db::{
     DatabaseHashedPostState, DatabaseHashedStorage, DatabaseProof, DatabaseStateRoot,
-    DatabaseStorageProof, DatabaseStorageRoot, DatabaseTrieWitness,
+    DatabaseStorageProof, DatabaseStorageRoot, DatabaseTrieWitness, StateCommitment,
 };
-use std::fmt::Debug;
+use std::{fmt::Debug, marker::PhantomData};
 
 /// State provider for a given block number which takes a tx reference.
 ///
@@ -40,7 +40,7 @@ use std::fmt::Debug;
 /// - [`tables::AccountChangeSets`]
 /// - [`tables::StorageChangeSets`]
 #[derive(Debug)]
-pub struct HistoricalStateProviderRef<'b, TX: DbTx> {
+pub struct HistoricalStateProviderRef<'b, TX: DbTx, SC: StateCommitment> {
     /// Transaction
     tx: &'b TX,
     /// Block number is main index for the history state of accounts and storages.
@@ -49,6 +49,8 @@ pub struct HistoricalStateProviderRef<'b, TX: DbTx> {
     lowest_available_blocks: LowestAvailableBlocks,
     /// Static File provider
     static_file_provider: StaticFileProvider,
+    /// Marker to associate the `StateCommitment` type with this provider.
+    _marker: PhantomData<SC>,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -59,14 +61,20 @@ pub enum HistoryInfo {
     MaybeInPlainState,
 }
 
-impl<'b, TX: DbTx> HistoricalStateProviderRef<'b, TX> {
+impl<'b, TX: DbTx, SC: StateCommitment> HistoricalStateProviderRef<'b, TX, SC> {
     /// Create new `StateProvider` for historical block number
     pub fn new(
         tx: &'b TX,
         block_number: BlockNumber,
         static_file_provider: StaticFileProvider,
     ) -> Self {
-        Self { tx, block_number, lowest_available_blocks: Default::default(), static_file_provider }
+        Self {
+            tx,
+            block_number,
+            lowest_available_blocks: Default::default(),
+            static_file_provider,
+            _marker: PhantomData,
+        }
     }
 
     /// Create new `StateProvider` for historical block number and lowest block numbers at which
@@ -77,7 +85,13 @@ impl<'b, TX: DbTx> HistoricalStateProviderRef<'b, TX> {
         lowest_available_blocks: LowestAvailableBlocks,
         static_file_provider: StaticFileProvider,
     ) -> Self {
-        Self { tx, block_number, lowest_available_blocks, static_file_provider }
+        Self {
+            tx,
+            block_number,
+            lowest_available_blocks,
+            static_file_provider,
+            _marker: PhantomData,
+        }
     }
 
     /// Lookup an account in the `AccountsHistory` table
@@ -247,7 +261,7 @@ impl<'b, TX: DbTx> HistoricalStateProviderRef<'b, TX> {
     }
 }
 
-impl<TX: DbTx> AccountReader for HistoricalStateProviderRef<'_, TX> {
+impl<TX: DbTx, SC: StateCommitment> AccountReader for HistoricalStateProviderRef<'_, TX, SC> {
     /// Get basic account information.
     fn basic_account(&self, address: Address) -> ProviderResult<Option<Account>> {
         match self.account_history_lookup(address)? {
@@ -269,7 +283,7 @@ impl<TX: DbTx> AccountReader for HistoricalStateProviderRef<'_, TX> {
     }
 }
 
-impl<TX: DbTx> BlockHashReader for HistoricalStateProviderRef<'_, TX> {
+impl<TX: DbTx, SC: StateCommitment> BlockHashReader for HistoricalStateProviderRef<'_, TX, SC> {
     /// Get block hash by number.
     fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
         self.static_file_provider.get_with_static_file_or_database(
@@ -305,7 +319,7 @@ impl<TX: DbTx> BlockHashReader for HistoricalStateProviderRef<'_, TX> {
     }
 }
 
-impl<TX: DbTx> StateRootProvider for HistoricalStateProviderRef<'_, TX> {
+impl<TX: DbTx, SC: StateCommitment> StateRootProvider for HistoricalStateProviderRef<'_, TX, SC> {
     fn state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
         let mut revert_state = self.revert_state()?;
         revert_state.extend(hashed_state);
@@ -339,7 +353,7 @@ impl<TX: DbTx> StateRootProvider for HistoricalStateProviderRef<'_, TX> {
     }
 }
 
-impl<TX: DbTx> StorageRootProvider for HistoricalStateProviderRef<'_, TX> {
+impl<TX: DbTx, SC: StateCommitment> StorageRootProvider for HistoricalStateProviderRef<'_, TX, SC> {
     fn storage_root(
         &self,
         address: Address,
@@ -364,7 +378,7 @@ impl<TX: DbTx> StorageRootProvider for HistoricalStateProviderRef<'_, TX> {
     }
 }
 
-impl<TX: DbTx> StateProofProvider for HistoricalStateProviderRef<'_, TX> {
+impl<TX: DbTx, SC: StateCommitment> StateProofProvider for HistoricalStateProviderRef<'_, TX, SC> {
     /// Get account and storage proofs.
     fn proof(
         &self,
@@ -396,7 +410,7 @@ impl<TX: DbTx> StateProofProvider for HistoricalStateProviderRef<'_, TX> {
     }
 }
 
-impl<TX: DbTx> StateProvider for HistoricalStateProviderRef<'_, TX> {
+impl<TX: DbTx, SC: StateCommitment> StateProvider for HistoricalStateProviderRef<'_, TX, SC> {
     /// Get storage.
     fn storage(
         &self,
@@ -436,7 +450,7 @@ impl<TX: DbTx> StateProvider for HistoricalStateProviderRef<'_, TX> {
 /// State provider for a given block number.
 /// For more detailed description, see [`HistoricalStateProviderRef`].
 #[derive(Debug)]
-pub struct HistoricalStateProvider<TX: DbTx> {
+pub struct HistoricalStateProvider<TX: DbTx, SC: StateCommitment> {
     /// Database transaction
     tx: TX,
     /// State at the block number is the main indexer of the state.
@@ -445,16 +459,24 @@ pub struct HistoricalStateProvider<TX: DbTx> {
     lowest_available_blocks: LowestAvailableBlocks,
     /// Static File provider
     static_file_provider: StaticFileProvider,
+    /// Marker to associate the `StateCommitment` type with this provider.
+    _marker: PhantomData<SC>,
 }
 
-impl<TX: DbTx> HistoricalStateProvider<TX> {
+impl<TX: DbTx, SC: StateCommitment> HistoricalStateProvider<TX, SC> {
     /// Create new `StateProvider` for historical block number
     pub fn new(
         tx: TX,
         block_number: BlockNumber,
         static_file_provider: StaticFileProvider,
     ) -> Self {
-        Self { tx, block_number, lowest_available_blocks: Default::default(), static_file_provider }
+        Self {
+            tx,
+            block_number,
+            lowest_available_blocks: Default::default(),
+            static_file_provider,
+            _marker: PhantomData,
+        }
     }
 
     /// Set the lowest block number at which the account history is available.
@@ -477,7 +499,7 @@ impl<TX: DbTx> HistoricalStateProvider<TX> {
 
     /// Returns a new provider that takes the `TX` as reference
     #[inline(always)]
-    fn as_ref(&self) -> HistoricalStateProviderRef<'_, TX> {
+    fn as_ref(&self) -> HistoricalStateProviderRef<'_, TX, SC> {
         HistoricalStateProviderRef::new_with_lowest_available_blocks(
             &self.tx,
             self.block_number,
@@ -488,7 +510,7 @@ impl<TX: DbTx> HistoricalStateProvider<TX> {
 }
 
 // Delegates all provider impls to [HistoricalStateProviderRef]
-delegate_provider_impls!(HistoricalStateProvider<TX> where [TX: DbTx]);
+delegate_provider_impls!(HistoricalStateProvider<TX, SC> where [TX: DbTx, SC: StateCommitment]);
 
 /// Lowest blocks at which different parts of the state are available.
 /// They may be [Some] if pruning is enabled.
@@ -534,6 +556,18 @@ mod tests {
     };
     use reth_primitives::{Account, StorageEntry};
     use reth_storage_errors::provider::ProviderError;
+    use reth_trie_db::{MerklePatriciaTrie, StateCommitment};
+
+    type TestHistoricalStateProviderRefRO<'a> = HistoricalStateProviderRef<
+        'a,
+        reth_db::mdbx::tx::Tx<reth_db::mdbx::RO>,
+        MerklePatriciaTrie,
+    >;
+    type TestHistoricalStateProviderRefRW<'a> = HistoricalStateProviderRef<
+        'a,
+        reth_db::mdbx::tx::Tx<reth_db::mdbx::RW>,
+        MerklePatriciaTrie,
+    >;
 
     const ADDRESS: Address = address!("0000000000000000000000000000000000000001");
     const HIGHER_ADDRESS: Address = address!("0000000000000000000000000000000000000005");
@@ -541,8 +575,8 @@ mod tests {
 
     const fn assert_state_provider<T: StateProvider>() {}
     #[allow(dead_code)]
-    const fn assert_historical_state_provider<T: DbTx>() {
-        assert_state_provider::<HistoricalStateProvider<T>>();
+    const fn assert_historical_state_provider<T: DbTx, SC: StateCommitment>() {
+        assert_state_provider::<HistoricalStateProvider<T, SC>>();
     }
 
     #[test]
@@ -613,58 +647,58 @@ mod tests {
 
         // run
         assert_eq!(
-            HistoricalStateProviderRef::new(&tx, 1, static_file_provider.clone())
+            TestHistoricalStateProviderRefRO::new(&tx, 1, static_file_provider.clone())
                 .basic_account(ADDRESS),
             Ok(None)
         );
         assert_eq!(
-            HistoricalStateProviderRef::new(&tx, 2, static_file_provider.clone())
+            TestHistoricalStateProviderRefRO::new(&tx, 2, static_file_provider.clone())
                 .basic_account(ADDRESS),
             Ok(Some(acc_at3))
         );
         assert_eq!(
-            HistoricalStateProviderRef::new(&tx, 3, static_file_provider.clone())
+            TestHistoricalStateProviderRefRO::new(&tx, 3, static_file_provider.clone())
                 .basic_account(ADDRESS),
             Ok(Some(acc_at3))
         );
         assert_eq!(
-            HistoricalStateProviderRef::new(&tx, 4, static_file_provider.clone())
+            TestHistoricalStateProviderRefRO::new(&tx, 4, static_file_provider.clone())
                 .basic_account(ADDRESS),
             Ok(Some(acc_at7))
         );
         assert_eq!(
-            HistoricalStateProviderRef::new(&tx, 7, static_file_provider.clone())
+            TestHistoricalStateProviderRefRO::new(&tx, 7, static_file_provider.clone())
                 .basic_account(ADDRESS),
             Ok(Some(acc_at7))
         );
         assert_eq!(
-            HistoricalStateProviderRef::new(&tx, 9, static_file_provider.clone())
+            TestHistoricalStateProviderRefRO::new(&tx, 9, static_file_provider.clone())
                 .basic_account(ADDRESS),
             Ok(Some(acc_at10))
         );
         assert_eq!(
-            HistoricalStateProviderRef::new(&tx, 10, static_file_provider.clone())
+            TestHistoricalStateProviderRefRO::new(&tx, 10, static_file_provider.clone())
                 .basic_account(ADDRESS),
             Ok(Some(acc_at10))
         );
         assert_eq!(
-            HistoricalStateProviderRef::new(&tx, 11, static_file_provider.clone())
+            TestHistoricalStateProviderRefRO::new(&tx, 11, static_file_provider.clone())
                 .basic_account(ADDRESS),
             Ok(Some(acc_at15))
         );
         assert_eq!(
-            HistoricalStateProviderRef::new(&tx, 16, static_file_provider.clone())
+            TestHistoricalStateProviderRefRO::new(&tx, 16, static_file_provider.clone())
                 .basic_account(ADDRESS),
             Ok(Some(acc_plain))
         );
 
         assert_eq!(
-            HistoricalStateProviderRef::new(&tx, 1, static_file_provider.clone())
+            TestHistoricalStateProviderRefRO::new(&tx, 1, static_file_provider.clone())
                 .basic_account(HIGHER_ADDRESS),
             Ok(None)
         );
         assert_eq!(
-            HistoricalStateProviderRef::new(&tx, 1000, static_file_provider)
+            TestHistoricalStateProviderRefRO::new(&tx, 1000, static_file_provider)
                 .basic_account(HIGHER_ADDRESS),
             Ok(Some(higher_acc_plain))
         );
@@ -725,52 +759,52 @@ mod tests {
 
         // run
         assert_eq!(
-            HistoricalStateProviderRef::new(&tx, 0, static_file_provider.clone())
+            TestHistoricalStateProviderRefRO::new(&tx, 0, static_file_provider.clone())
                 .storage(ADDRESS, STORAGE),
             Ok(None)
         );
         assert_eq!(
-            HistoricalStateProviderRef::new(&tx, 3, static_file_provider.clone())
+            TestHistoricalStateProviderRefRO::new(&tx, 3, static_file_provider.clone())
                 .storage(ADDRESS, STORAGE),
             Ok(Some(U256::ZERO))
         );
         assert_eq!(
-            HistoricalStateProviderRef::new(&tx, 4, static_file_provider.clone())
+            TestHistoricalStateProviderRefRO::new(&tx, 4, static_file_provider.clone())
                 .storage(ADDRESS, STORAGE),
             Ok(Some(entry_at7.value))
         );
         assert_eq!(
-            HistoricalStateProviderRef::new(&tx, 7, static_file_provider.clone())
+            TestHistoricalStateProviderRefRO::new(&tx, 7, static_file_provider.clone())
                 .storage(ADDRESS, STORAGE),
             Ok(Some(entry_at7.value))
         );
         assert_eq!(
-            HistoricalStateProviderRef::new(&tx, 9, static_file_provider.clone())
+            TestHistoricalStateProviderRefRO::new(&tx, 9, static_file_provider.clone())
                 .storage(ADDRESS, STORAGE),
             Ok(Some(entry_at10.value))
         );
         assert_eq!(
-            HistoricalStateProviderRef::new(&tx, 10, static_file_provider.clone())
+            TestHistoricalStateProviderRefRO::new(&tx, 10, static_file_provider.clone())
                 .storage(ADDRESS, STORAGE),
             Ok(Some(entry_at10.value))
         );
         assert_eq!(
-            HistoricalStateProviderRef::new(&tx, 11, static_file_provider.clone())
+            TestHistoricalStateProviderRefRO::new(&tx, 11, static_file_provider.clone())
                 .storage(ADDRESS, STORAGE),
             Ok(Some(entry_at15.value))
         );
         assert_eq!(
-            HistoricalStateProviderRef::new(&tx, 16, static_file_provider.clone())
+            TestHistoricalStateProviderRefRO::new(&tx, 16, static_file_provider.clone())
                 .storage(ADDRESS, STORAGE),
             Ok(Some(entry_plain.value))
         );
         assert_eq!(
-            HistoricalStateProviderRef::new(&tx, 1, static_file_provider.clone())
+            TestHistoricalStateProviderRefRO::new(&tx, 1, static_file_provider.clone())
                 .storage(HIGHER_ADDRESS, STORAGE),
             Ok(None)
         );
         assert_eq!(
-            HistoricalStateProviderRef::new(&tx, 1000, static_file_provider)
+            TestHistoricalStateProviderRefRO::new(&tx, 1000, static_file_provider)
                 .storage(HIGHER_ADDRESS, STORAGE),
             Ok(Some(higher_entry_plain.value))
         );
@@ -784,7 +818,7 @@ mod tests {
 
         // provider block_number < lowest available block number,
         // i.e. state at provider block is pruned
-        let provider = HistoricalStateProviderRef::new_with_lowest_available_blocks(
+        let provider = TestHistoricalStateProviderRefRW::new_with_lowest_available_blocks(
             &tx,
             2,
             LowestAvailableBlocks {
@@ -804,7 +838,7 @@ mod tests {
 
         // provider block_number == lowest available block number,
         // i.e. state at provider block is available
-        let provider = HistoricalStateProviderRef::new_with_lowest_available_blocks(
+        let provider = TestHistoricalStateProviderRefRW::new_with_lowest_available_blocks(
             &tx,
             2,
             LowestAvailableBlocks {
@@ -821,7 +855,7 @@ mod tests {
 
         // provider block_number == lowest available block number,
         // i.e. state at provider block is available
-        let provider = HistoricalStateProviderRef::new_with_lowest_available_blocks(
+        let provider = TestHistoricalStateProviderRefRW::new_with_lowest_available_blocks(
             &tx,
             2,
             LowestAvailableBlocks {

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -22,33 +22,36 @@ use reth_trie::{
 };
 use reth_trie_db::{
     DatabaseProof, DatabaseStateRoot, DatabaseStorageProof, DatabaseStorageRoot,
-    DatabaseTrieWitness,
+    DatabaseTrieWitness, StateCommitment,
 };
+use std::marker::PhantomData;
 
 /// State provider over latest state that takes tx reference.
 #[derive(Debug)]
-pub struct LatestStateProviderRef<'b, TX: DbTx> {
+pub struct LatestStateProviderRef<'b, TX: DbTx, SC: StateCommitment> {
     /// database transaction
     tx: &'b TX,
     /// Static File provider
     static_file_provider: StaticFileProvider,
+    /// Marker to associate the `StateCommitment` type with this provider.
+    _marker: PhantomData<SC>,
 }
 
-impl<'b, TX: DbTx> LatestStateProviderRef<'b, TX> {
+impl<'b, TX: DbTx, SC: StateCommitment> LatestStateProviderRef<'b, TX, SC> {
     /// Create new state provider
     pub const fn new(tx: &'b TX, static_file_provider: StaticFileProvider) -> Self {
-        Self { tx, static_file_provider }
+        Self { tx, static_file_provider, _marker: PhantomData }
     }
 }
 
-impl<TX: DbTx> AccountReader for LatestStateProviderRef<'_, TX> {
+impl<TX: DbTx, SC: StateCommitment> AccountReader for LatestStateProviderRef<'_, TX, SC> {
     /// Get basic account information.
     fn basic_account(&self, address: Address) -> ProviderResult<Option<Account>> {
         self.tx.get::<tables::PlainAccountState>(address).map_err(Into::into)
     }
 }
 
-impl<TX: DbTx> BlockHashReader for LatestStateProviderRef<'_, TX> {
+impl<TX: DbTx, SC: StateCommitment> BlockHashReader for LatestStateProviderRef<'_, TX, SC> {
     /// Get block hash by number.
     fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
         self.static_file_provider.get_with_static_file_or_database(
@@ -84,7 +87,7 @@ impl<TX: DbTx> BlockHashReader for LatestStateProviderRef<'_, TX> {
     }
 }
 
-impl<TX: DbTx> StateRootProvider for LatestStateProviderRef<'_, TX> {
+impl<TX: DbTx, SC: StateCommitment> StateRootProvider for LatestStateProviderRef<'_, TX, SC> {
     fn state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
         StateRoot::overlay_root(self.tx, hashed_state)
             .map_err(|err| ProviderError::Database(err.into()))
@@ -112,7 +115,7 @@ impl<TX: DbTx> StateRootProvider for LatestStateProviderRef<'_, TX> {
     }
 }
 
-impl<TX: DbTx> StorageRootProvider for LatestStateProviderRef<'_, TX> {
+impl<TX: DbTx, SC: StateCommitment> StorageRootProvider for LatestStateProviderRef<'_, TX, SC> {
     fn storage_root(
         &self,
         address: Address,
@@ -133,7 +136,7 @@ impl<TX: DbTx> StorageRootProvider for LatestStateProviderRef<'_, TX> {
     }
 }
 
-impl<TX: DbTx> StateProofProvider for LatestStateProviderRef<'_, TX> {
+impl<TX: DbTx, SC: StateCommitment> StateProofProvider for LatestStateProviderRef<'_, TX, SC> {
     fn proof(
         &self,
         input: TrieInput,
@@ -161,7 +164,7 @@ impl<TX: DbTx> StateProofProvider for LatestStateProviderRef<'_, TX> {
     }
 }
 
-impl<TX: DbTx> StateProvider for LatestStateProviderRef<'_, TX> {
+impl<TX: DbTx, SC: StateCommitment> StateProvider for LatestStateProviderRef<'_, TX, SC> {
     /// Get storage.
     fn storage(
         &self,
@@ -185,28 +188,30 @@ impl<TX: DbTx> StateProvider for LatestStateProviderRef<'_, TX> {
 
 /// State provider for the latest state.
 #[derive(Debug)]
-pub struct LatestStateProvider<TX: DbTx> {
+pub struct LatestStateProvider<TX: DbTx, SC: StateCommitment> {
     /// database transaction
     db: TX,
     /// Static File provider
     static_file_provider: StaticFileProvider,
+    /// Marker to associate the `StateCommitment` type with this provider.
+    _marker: PhantomData<SC>,
 }
 
-impl<TX: DbTx> LatestStateProvider<TX> {
+impl<TX: DbTx, SC: StateCommitment> LatestStateProvider<TX, SC> {
     /// Create new state provider
     pub const fn new(db: TX, static_file_provider: StaticFileProvider) -> Self {
-        Self { db, static_file_provider }
+        Self { db, static_file_provider, _marker: PhantomData }
     }
 
     /// Returns a new provider that takes the `TX` as reference
     #[inline(always)]
-    fn as_ref(&self) -> LatestStateProviderRef<'_, TX> {
+    fn as_ref(&self) -> LatestStateProviderRef<'_, TX, SC> {
         LatestStateProviderRef::new(&self.db, self.static_file_provider.clone())
     }
 }
 
 // Delegates all provider impls to [LatestStateProviderRef]
-delegate_provider_impls!(LatestStateProvider<TX> where [TX: DbTx]);
+delegate_provider_impls!(LatestStateProvider<TX, SC> where [TX: DbTx, SC: StateCommitment]);
 
 #[cfg(test)]
 mod tests {
@@ -214,7 +219,7 @@ mod tests {
 
     const fn assert_state_provider<T: StateProvider>() {}
     #[allow(dead_code)]
-    const fn assert_latest_state_provider<T: DbTx>() {
-        assert_state_provider::<LatestStateProvider<T>>();
+    const fn assert_latest_state_provider<T: DbTx, SC: StateCommitment>() {
+        assert_state_provider::<LatestStateProvider<T, SC>>();
     }
 }

--- a/crates/storage/provider/src/test_utils/blocks.rs
+++ b/crates/storage/provider/src/test_utils/blocks.rs
@@ -13,12 +13,13 @@ use reth_primitives::{
     Signature, Transaction, TransactionSigned, TxType, Withdrawal, Withdrawals,
 };
 use reth_trie::root::{state_root_unhashed, storage_root_unhashed};
+use reth_trie_db::StateCommitment;
 use revm::{db::BundleState, primitives::AccountInfo};
 use std::{str::FromStr, sync::LazyLock};
 
 /// Assert genesis block
-pub fn assert_genesis_block<DB: Database, Spec: Send + Sync>(
-    provider: &DatabaseProviderRW<DB, Spec>,
+pub fn assert_genesis_block<DB: Database, Spec: Send + Sync, SC: StateCommitment>(
+    provider: &DatabaseProviderRW<DB, Spec, SC>,
     g: SealedBlock,
 ) {
     let n = g.number;

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -34,6 +34,7 @@ use reth_trie::{
     updates::TrieUpdates, AccountProof, HashedPostState, HashedStorage, MultiProof, StorageProof,
     TrieInput,
 };
+use reth_trie_db::MerklePatriciaTrie;
 use revm::primitives::{BlockEnv, CfgEnvWithHandlerCfg};
 use std::{
     collections::BTreeMap,
@@ -152,8 +153,8 @@ impl MockEthProvider {
 
 impl DatabaseProviderFactory for MockEthProvider {
     type DB = DatabaseMock;
-    type Provider = DatabaseProvider<TxMock, ChainSpec>;
-    type ProviderRW = DatabaseProvider<TxMock, ChainSpec>;
+    type Provider = DatabaseProvider<TxMock, ChainSpec, MerklePatriciaTrie>;
+    type ProviderRW = DatabaseProvider<TxMock, ChainSpec, MerklePatriciaTrie>;
 
     fn database_provider_ro(&self) -> ProviderResult<Self::Provider> {
         Err(ConsistentViewError::Syncing { best_block: GotExpected::new(0, 0) }.into())

--- a/crates/storage/storage-api/src/state.rs
+++ b/crates/storage/storage-api/src/state.rs
@@ -90,6 +90,13 @@ pub trait TryIntoHistoricalStateProvider {
     ) -> ProviderResult<StateProviderBox>;
 }
 
+/// Trait implemented for database providers that can be converted into a latest state provider
+/// reference.
+pub trait ToLatestStateProviderRef {
+    /// Returns a [`StateProvider`] for the latest state.
+    fn latest<'a>(&'a self) -> Box<dyn 'a + StateProvider>;
+}
+
 /// Light wrapper that returns `StateProvider` implementations that correspond to the given
 /// `BlockNumber`, the latest state, or the pending state.
 ///

--- a/crates/trie/db/tests/trie.rs
+++ b/crates/trie/db/tests/trie.rs
@@ -693,8 +693,8 @@ fn storage_trie_around_extension_node() {
     assert_trie_updates(updates.storage_nodes_ref());
 }
 
-fn extension_node_storage_trie<Spec: Send + Sync>(
-    tx: &DatabaseProviderRW<Arc<TempDatabase<DatabaseEnv>>, Spec>,
+fn extension_node_storage_trie<Spec: Send + Sync, SC: Send + Sync>(
+    tx: &DatabaseProviderRW<Arc<TempDatabase<DatabaseEnv>>, Spec, SC>,
     hashed_address: B256,
 ) -> (B256, StorageTrieUpdates) {
     let value = U256::from(1);
@@ -721,8 +721,8 @@ fn extension_node_storage_trie<Spec: Send + Sync>(
     (root, trie_updates)
 }
 
-fn extension_node_trie<Spec: Send + Sync>(
-    tx: &DatabaseProviderRW<Arc<TempDatabase<DatabaseEnv>>, Spec>,
+fn extension_node_trie<Spec: Send + Sync, SC: Send + Sync>(
+    tx: &DatabaseProviderRW<Arc<TempDatabase<DatabaseEnv>>, Spec, SC>,
 ) -> B256 {
     let a = Account { nonce: 0, balance: U256::from(1u64), bytecode_hash: Some(B256::random()) };
     let val = encode_account(a, None);


### PR DESCRIPTION
# Overview
This PR introduces the `StateCommitment` type in `StateProviders` such that the type can be used for state commitment operations.

This should be merged after the target branch has been merged into main in upstream reth main. After the target branch has been merged upstream we will change the target to point to upstream reth.