### PR TITLE
fix: docs significant errors

### DIFF
--- a/docs/crates/db.md
+++ b/docs/crates/db.md
@@ -213,7 +213,7 @@ pub trait DbTxMut: Send + Sync {
 
 Let's take a look at the `DbTx` and `DbTxMut` traits in action.
 
-Revisiting the `DatabaseProvider<Tx>` struct as an exampl, the `DatabaseProvider<Tx>::header_by_number()` function uses the `DbTx::get()` function to get a header from the `Headers` table.
+Revisiting the `DatabaseProvider<Tx>` struct as an example, the `DatabaseProvider<Tx>::header_by_number()` function uses the `DbTx::get()` function to get a header from the `Headers` table.
 
 [File: crates/storage/provider/src/providers/database/provider.rs](https://github.com/paradigmxyz/reth/blob/bf9cac7571f018fec581fe3647862dab527aeafb/crates/storage/provider/src/providers/database/provider.rs#L1319-L1336)
 

--- a/docs/design/goals.md
+++ b/docs/design/goals.md
@@ -34,7 +34,7 @@ Why? This is a win for everyone. RPC providers meet more impressive SLAs, MEV se
 
 The biggest bottleneck in this pipeline is not the execution of the EVM interpreter itself, but rather in accessing state and managing I/O. As such, we think the largest optimizations to be made are closest to the DB layer.
 
-Ideally, we can achieve such fast runtime operation that we can avoid storing certain things (e.g.?) on the disk, and are able to generate them on the fly, instead - minimizing disk footprint.
+Ideally, we can achieve such fast runtime operation that we can avoid storing certain things on the disk, and are able to generate them on the fly, instead - minimizing disk footprint.
 
 ---
 

--- a/docs/repo/layout.md
+++ b/docs/repo/layout.md
@@ -92,7 +92,7 @@ Crates related to transaction execution.
 - [`revm`](../../crates/revm): Revm utils and implementations specific to reth.
 - [`evm`](../../crates/evm): Traits for configuring an EVM specifics.
 - [`execution-types`](../../crates/evm/execution-types): Commonly used types for (EVM) block execution.
-- [`execution-errors`](../../crates/evm/execution-errors): Commonly used error types used when doing block execution.
+- [`execution-errors`](../../crates/evm/execution-errors): Commonly used error types when doing block execution.
 
 ### Sync
 
@@ -138,7 +138,7 @@ The IPC transport lives in [`rpc/ipc`](../../crates/rpc/ipc).
 
 #### Utilities Crates
 
-- [`rpc/rpc-types-compat`](../../crates/rpc/rpc-types-compat): This crate various helper functions to convert between reth primitive types and rpc types.
+- [`rpc/rpc-types-compat`](../../crates/rpc/rpc-types-compat): This crate provides various helper functions to convert between reth primitive types and rpc types.
 - [`rpc/layer`](../../crates/rpc/rpc-layer/): Some RPC middleware layers (e.g. `AuthValidator`, `JwtAuthValidator`)
 - [`rpc/rpc-testing-util`](../../crates/rpc/rpc-testing-util/): Reth RPC testing helpers
 


### PR DESCRIPTION
I have reviewed the ***CONTRIBUTING.md*** document, specifically the ***Contributions Related to Spelling and Grammar*** section:

_"At this time, we will not be accepting contributions that only fix spelling or grammatical errors in documentation, code or elsewhere."_

I submitted this pull request to bring your attention to the errors and typos present in the documentation, so that you can address and correct them accordingly. I am very pleased to help you with correcting the text. This is very important for clarity. Thank you.