### PR TITLE
feat: `l1_fee` field on Receipt

### DIFF
--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -817,6 +817,8 @@ mod tests {
             cumulative_gas_used: 46913,
             logs: vec![],
             success: true,
+            #[cfg(feature = "scroll")]
+            l1_fee: alloy_primitives::U256::ZERO,
         };
 
         // Create another random receipt object, receipt2
@@ -825,6 +827,8 @@ mod tests {
             cumulative_gas_used: 1325345,
             logs: vec![],
             success: true,
+            #[cfg(feature = "scroll")]
+            l1_fee: alloy_primitives::U256::ZERO,
         };
 
         // Create a Receipts object with a vector of receipt vectors

--- a/crates/evm/execution-types/src/execution_outcome.rs
+++ b/crates/evm/execution-types/src/execution_outcome.rs
@@ -398,6 +398,8 @@ mod tests {
                 cumulative_gas_used: 46913,
                 logs: vec![],
                 success: true,
+                #[cfg(feature = "scroll")]
+                l1_fee: U256::ZERO,
             })]],
         };
 
@@ -460,6 +462,8 @@ mod tests {
                 cumulative_gas_used: 46913,
                 logs: vec![],
                 success: true,
+                #[cfg(feature = "scroll")]
+                l1_fee: U256::ZERO,
             })]],
         };
 
@@ -495,6 +499,8 @@ mod tests {
                 cumulative_gas_used: 46913,
                 logs: vec![Log::<LogData>::default()],
                 success: true,
+                #[cfg(feature = "scroll")]
+                l1_fee: U256::ZERO,
             })]],
         };
 
@@ -527,6 +533,8 @@ mod tests {
                 cumulative_gas_used: 46913,
                 logs: vec![Log::<LogData>::default()],
                 success: true,
+                #[cfg(feature = "scroll")]
+                l1_fee: U256::ZERO,
             })]],
         };
 
@@ -553,6 +561,8 @@ mod tests {
                 cumulative_gas_used: 46913,
                 logs: vec![Log::<LogData>::default()],
                 success: true,
+                #[cfg(feature = "scroll")]
+                l1_fee: U256::ZERO,
             })]
         );
     }
@@ -567,6 +577,8 @@ mod tests {
                 cumulative_gas_used: 46913,
                 logs: vec![Log::<LogData>::default()],
                 success: true,
+                #[cfg(feature = "scroll")]
+                l1_fee: U256::ZERO,
             })]],
         };
 
@@ -615,6 +627,8 @@ mod tests {
             cumulative_gas_used: 46913,
             logs: vec![],
             success: true,
+            #[cfg(feature = "scroll")]
+            l1_fee: U256::ZERO,
         };
 
         // Create a Receipts object with a vector of receipt vectors
@@ -664,6 +678,8 @@ mod tests {
             cumulative_gas_used: 46913,
             logs: vec![],
             success: true,
+            #[cfg(feature = "scroll")]
+            l1_fee: U256::ZERO,
         };
 
         // Create a Receipts object containing the receipt.
@@ -708,6 +724,8 @@ mod tests {
             cumulative_gas_used: 46913,
             logs: vec![],
             success: true,
+            #[cfg(feature = "scroll")]
+            l1_fee: U256::ZERO,
         };
 
         // Create a Receipts object with a vector of receipt vectors

--- a/crates/primitives/src/proofs.rs
+++ b/crates/primitives/src/proofs.rs
@@ -94,6 +94,8 @@ mod tests {
                 success: true,
                 cumulative_gas_used: 102068,
                 logs,
+                #[cfg(feature = "scroll")]
+                l1_fee: U256::from(0xffffff),
             },
             bloom,
         };

--- a/crates/storage/db-api/Cargo.toml
+++ b/crates/storage/db-api/Cargo.toml
@@ -82,3 +82,4 @@ arbitrary = [
     "alloy-consensus/arbitrary",
 ]
 optimism = ["reth-primitives/optimism", "reth-codecs/optimism"]
+scroll = ["reth-primitives/scroll"]

--- a/crates/storage/db-api/src/models/mod.rs
+++ b/crates/storage/db-api/src/models/mod.rs
@@ -335,7 +335,10 @@ mod tests {
         assert_eq!(PruneCheckpoint::bitflag_encoded_bytes(), 1);
         assert_eq!(PruneMode::bitflag_encoded_bytes(), 1);
         assert_eq!(PruneSegment::bitflag_encoded_bytes(), 1);
+        #[cfg(not(feature = "scroll"))]
         assert_eq!(Receipt::bitflag_encoded_bytes(), 1);
+        #[cfg(feature = "scroll")]
+        assert_eq!(Receipt::bitflag_encoded_bytes(), 2);
         assert_eq!(StageCheckpoint::bitflag_encoded_bytes(), 1);
         assert_eq!(StageUnitCheckpoint::bitflag_encoded_bytes(), 1);
         assert_eq!(StoredBlockBodyIndices::bitflag_encoded_bytes(), 1);
@@ -356,7 +359,10 @@ mod tests {
         validate_bitflag_backwards_compat!(PruneCheckpoint, UnusedBits::NotZero);
         validate_bitflag_backwards_compat!(PruneMode, UnusedBits::Zero);
         validate_bitflag_backwards_compat!(PruneSegment, UnusedBits::Zero);
+        #[cfg(not(feature = "scroll"))]
         validate_bitflag_backwards_compat!(Receipt, UnusedBits::Zero);
+        #[cfg(feature = "scroll")]
+        validate_bitflag_backwards_compat!(Receipt, UnusedBits::NotZero);
         validate_bitflag_backwards_compat!(StageCheckpoint, UnusedBits::NotZero);
         validate_bitflag_backwards_compat!(StageUnitCheckpoint, UnusedBits::Zero);
         validate_bitflag_backwards_compat!(StoredBlockBodyIndices, UnusedBits::Zero);


### PR DESCRIPTION
This PR builds on top of #41 and should only be reviewed once 41 is merged. 

Adds the `l1_fee` field on the primitives `Receipt` from Reth. 
Skips the field when RLP encoding the `Receipt` as the `l1_fee` field is not part of the consensus encoding of the [receipt](https://github.com/scroll-tech/go-ethereum/blob/develop/core/types/receipt.go#L96-L102). The field is still included in the `Compact` implementation meaning the `Receipt` will be saved in storage with the L1 fee.

Builds towards #7 