### PR TITLE
Fix: embed zktrie spec in rust docs using github links for images

### DIFF
--- a/crates/net/network/src/transactions/validation.rs
+++ b/crates/net/network/src/transactions/validation.rs
@@ -3,7 +3,7 @@
 //! announcements. Validation and filtering of announcements is network dependent.
 
 use crate::metrics::{AnnouncedTxTypesMetrics, TxTypesCounter};
-use alloy_primitives::{Signature, TxHash};
+use alloy_primitives::{PrimitiveSignature, TxHash};
 use derive_more::{Deref, DerefMut};
 use reth_eth_wire::{
     DedupPayload, Eth68TxMetadata, HandleMempoolData, PartiallyValidData, ValidAnnouncementData,
@@ -14,7 +14,7 @@ use std::{fmt, fmt::Display, mem};
 use tracing::trace;
 
 /// The size of a decoded signature in bytes.
-pub const SIGNATURE_DECODED_SIZE_BYTES: usize = mem::size_of::<Signature>();
+pub const SIGNATURE_DECODED_SIZE_BYTES: usize = mem::size_of::<PrimitiveSignature>();
 
 /// Interface for validating a `(ty, size, hash)` tuple from a
 /// [`NewPooledTransactionHashes68`](reth_eth_wire::NewPooledTransactionHashes68)..

--- a/crates/scroll/trie/assets/zktrie.md
+++ b/crates/scroll/trie/assets/zktrie.md
@@ -3,7 +3,7 @@
 ## 1. Tree Structure
 
 <figure>
-<img src="arch.png" alt="zkTrie Structure" style="width:80%">
+<img src="https://raw.githubusercontent.com/scroll-tech/reth/refs/heads/scroll/crates/scroll/trie/assets/arch.png" alt="zkTrie Structure" style="width:80%">
 <figcaption align = "center"><b>Figure 1. zkTrie Structure</b></figcaption>
 </figure>
 
@@ -161,7 +161,7 @@ valueHash = h(storageValue[0:16], storageValue[16:32])
 ### 4.1 Insertion
 
 <figure>
-<img src="insertion.png" alt="zkTrie Structure" style="width:80%">
+<img src="https://raw.githubusercontent.com/scroll-tech/reth/refs/heads/scroll/crates/scroll/trie/assets/insertion.png" alt="zkTrie Structure" style="width:80%">
 <figcaption align = "center"><b>Figure 2. Insert a new leaf node to zkTrie</b></figcaption>
 </figure>
 
@@ -173,7 +173,7 @@ When we insert a new leaf node to the existing zkTrie, there could be two cases 
 ### 4.2 Deletion
 
 <figure>
-<img src="deletion.png" alt="zkTrie Structure" style="width:80%">
+<img src="https://raw.githubusercontent.com/scroll-tech/reth/refs/heads/scroll/crates/scroll/trie/assets/deletion.png" alt="zkTrie Structure" style="width:80%">
 <figcaption align = "center"><b>Figure 3. Delete a leaf node from the zkTrie</b></figcaption>
 </figure>
 

--- a/crates/scroll/trie/src/lib.rs
+++ b/crates/scroll/trie/src/lib.rs
@@ -1,7 +1,7 @@
 //! Fast binary Merkle-Patricia Trie (zktrie) state root calculator and proof generator for
 //! prefix-sorted bits.
 
-#![doc = include_str!("../assets/zktrie.md")]
+#![cfg_attr(not(doctest), doc = include_str!("../assets/zktrie.md"))]
 
 #[macro_use]
 #[allow(unused_imports)]

--- a/crates/scroll/trie/src/lib.rs
+++ b/crates/scroll/trie/src/lib.rs
@@ -1,4 +1,7 @@
-#![doc = include_str!("../README.md")]
+//! Fast binary Merkle-Patricia Trie (zktrie) state root calculator and proof generator for
+//! prefix-sorted bits.
+
+#![doc = include_str!("../assets/zktrie.md")]
 
 #[macro_use]
 #[allow(unused_imports)]


### PR DESCRIPTION
Previously we were using paths to images when defining the markdown for the zktrie spec. This was breaking the render when generating rust docs so instead we migrated to using links to the images hosted on github and also included the spec directly in the `trie` library docs instead of the `README.md`.