### PR TITLE
Fix `zktrie` Key Traversal

### DIFF
--- a/crates/scroll/state-commitment/src/root.rs
+++ b/crates/scroll/state-commitment/src/root.rs
@@ -233,10 +233,8 @@ where
 
                     let account = ScrollTrieAccount::from((account, storage_root));
                     let account_hash = PoseidonValueHasher::hash_account(account);
-                    hash_builder.add_leaf(
-                        Nibbles::unpack_and_truncate_bits(hashed_address),
-                        account_hash.as_slice(),
-                    );
+                    hash_builder
+                        .add_leaf(Nibbles::unpack_bits(hashed_address), account_hash.as_slice());
 
                     // Decide if we need to return intermediate progress.
                     let total_updates_len = updated_storage_nodes +
@@ -433,10 +431,7 @@ where
                 TrieElement::Leaf(hashed_slot, value) => {
                     let hashed_value = PoseidonValueHasher::hash_storage(value);
                     tracker.inc_leaf();
-                    hash_builder.add_leaf(
-                        Nibbles::unpack_and_truncate_bits(hashed_slot),
-                        hashed_value.as_ref(),
-                    );
+                    hash_builder.add_leaf(Nibbles::unpack_bits(hashed_slot), hashed_value.as_ref());
                 }
             }
         }

--- a/crates/scroll/trie/src/hash_builder.rs
+++ b/crates/scroll/trie/src/hash_builder.rs
@@ -468,7 +468,7 @@ mod test {
 
     #[test]
     fn test_convert_to_bit_representation() {
-        let nibbles = Nibbles::unpack_and_truncate_bits(vec![7, 8]);
+        let nibbles = Nibbles::unpack_bits(vec![7, 8]);
         let expected = [0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0];
         assert_eq!(nibbles.as_slice(), expected);
     }
@@ -478,7 +478,7 @@ mod test {
         // 64 byte nibble
         let hex = hex!("0102030405060708090a0b0c0d0e0f0102030405060708090a0b0c0d0e0f0102030405060708090a0b0c0d0e0f0102030405060708090a0b0c0d0e0f01020304");
         assert_eq!(hex.len(), 64);
-        let nibbles = Nibbles::unpack_and_truncate_bits(hex);
+        let nibbles = Nibbles::unpack_bits(hex);
         assert_eq!(nibbles.len(), 248);
     }
 

--- a/crates/scroll/trie/src/hash_builder.rs
+++ b/crates/scroll/trie/src/hash_builder.rs
@@ -479,7 +479,7 @@ mod test {
         let hex = hex!("0102030405060708090a0b0c0d0e0f0102030405060708090a0b0c0d0e0f0102030405060708090a0b0c0d0e0f0102030405060708090a0b0c0d0e0f01020304");
         assert_eq!(hex.len(), 64);
         let nibbles = Nibbles::unpack_bits(hex);
-        assert_eq!(nibbles.len(), 248);
+        assert_eq!(nibbles.len(), 254);
     }
 
     #[test]

--- a/crates/trie/trie/src/node_iter.rs
+++ b/crates/trie/trie/src/node_iter.rs
@@ -113,7 +113,7 @@ where
                     #[cfg(not(feature = "scroll"))]
                     let cmp = key < &Nibbles::unpack(hashed_key);
                     #[cfg(feature = "scroll")]
-                    let cmp = key < &Nibbles::unpack_and_truncate_bits(hashed_key);
+                    let cmp = key < &Nibbles::unpack_bits(hashed_key);
                     cmp
                 }) {
                     self.current_walker_key_checked = false;

--- a/crates/trie/trie/src/state.rs
+++ b/crates/trie/trie/src/state.rs
@@ -123,7 +123,7 @@ impl HashedPostState {
         for (hashed_address, account) in &self.accounts {
             // TODO(scroll): replace with key abstraction
             #[cfg(feature = "scroll")]
-            let nibbles = Nibbles::unpack_and_truncate_bits(hashed_address);
+            let nibbles = Nibbles::unpack_bits(hashed_address);
             #[cfg(not(feature = "scroll"))]
             let nibbles = Nibbles::unpack(hashed_address);
             account_prefix_set.insert(nibbles);
@@ -139,7 +139,7 @@ impl HashedPostState {
         for (hashed_address, hashed_storage) in &self.storages {
             // TODO(scroll): replace this with abstraction.
             #[cfg(feature = "scroll")]
-            let nibbles = Nibbles::unpack_and_truncate_bits(hashed_address);
+            let nibbles = Nibbles::unpack_bits(hashed_address);
             #[cfg(not(feature = "scroll"))]
             let nibbles = Nibbles::unpack(hashed_address);
             account_prefix_set.insert(nibbles);
@@ -268,7 +268,7 @@ impl HashedStorage {
             for hashed_slot in self.storage.keys() {
                 // TODO(scroll): replace this with key abstraction.
                 #[cfg(feature = "scroll")]
-                let nibbles = Nibbles::unpack_and_truncate_bits(hashed_slot);
+                let nibbles = Nibbles::unpack_bits(hashed_slot);
                 #[cfg(not(feature = "scroll"))]
                 let nibbles = Nibbles::unpack(hashed_slot);
                 prefix_set.insert(nibbles);


### PR DESCRIPTION
As described in #74 the key traversal truncation logic is incorrect in the spec. As such we update the key traversal logic to use all 254 bits of the key space (bn254 field size).

closes: #74 