### PR TITLE
feat: skip usage of `ScrollPostExecutionContext`

### DIFF
--- a/crates/scroll/revm/Cargo.toml
+++ b/crates/scroll/revm/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 revm = { version = "18.0.0", features = ["std"], default-features = false }
 
 # scroll
-reth-scroll-primitives.workspace = true
+reth-scroll-primitives = { workspace = true, optional = true }
 
 # misc
 serde = { workspace = true, optional = true }
@@ -26,21 +26,21 @@ default = ["std"]
 dev = ["revm/dev"]
 arbitrary = [
 	"revm/arbitrary",
-	"reth-scroll-primitives/arbitrary"
+	"reth-scroll-primitives?/arbitrary"
 ]
 asm-keccak = ["revm/asm-keccak"]
 c-kzg = ["revm/c-kzg"]
 optimism = ["revm/optimism"]
 serde = [
 	"revm/serde",
-	"serde/std",
-	"reth-scroll-primitives/serde"
+	"dep:serde",
+	"reth-scroll-primitives?/serde"
 ]
-scroll = ["revm/scroll-poseidon-codehash"]
+scroll = ["revm/scroll-poseidon-codehash", "dep:reth-scroll-primitives"]
 test-utils = ["revm/test-utils"]
 std = [
 	"revm/std",
-	"serde/std"
+	"serde?/std"
 ]
 
 blst = ["revm/blst"]

--- a/crates/scroll/revm/src/lib.rs
+++ b/crates/scroll/revm/src/lib.rs
@@ -3,9 +3,18 @@
 
 #![warn(unused_crate_dependencies)]
 
+#[cfg(feature = "serde")]
+use serde as _;
+
+#[cfg(feature = "scroll")]
 pub mod states;
-#[cfg(feature = "test-utils")]
+#[cfg(all(feature = "scroll", feature = "test-utils"))]
 mod test_utils;
+
+#[cfg(feature = "scroll")]
+pub use crate::states::ScrollAccountInfo as AccountInfo;
+#[cfg(not(feature = "scroll"))]
+pub use revm::primitives::AccountInfo;
 
 #[cfg(all(feature = "optimism", not(feature = "scroll")))]
 pub use revm::{primitives::OptimismFields, L1BlockInfo, L1_BLOCK_CONTRACT};
@@ -20,12 +29,6 @@ pub use revm::{
     ContextPrecompile, ContextPrecompiles, Evm, EvmBuilder, EvmContext, GetInspector, Inspector,
     JournaledState,
 };
-
-#[cfg(feature = "scroll")]
-pub use crate::states::ScrollAccountInfo as AccountInfo;
-#[cfg(not(feature = "scroll"))]
-pub use revm::primitives::AccountInfo;
-pub use states::ScrollAccountInfo;
 
 /// Shared module, available for all feature flags.
 pub mod shared {

--- a/crates/scroll/revm/src/states/account_info.rs
+++ b/crates/scroll/revm/src/states/account_info.rs
@@ -25,22 +25,24 @@ pub struct ScrollAccountInfo {
 }
 
 impl From<(AccountInfo, &ScrollPostExecutionContext)> for ScrollAccountInfo {
-    fn from((info, context): (AccountInfo, &ScrollPostExecutionContext)) -> Self {
-        let context = context.get(&info.code_hash).copied();
-        let (code_size, poseidon_code_hash) = context
-            .or_else(|| {
-                info.code
-                    .as_ref()
-                    .map(|code| (code.len() as u64, hash_code(code.original_byte_slice())))
-            })
-            .unwrap_or((0, POSEIDON_EMPTY));
+    fn from((info, _context): (AccountInfo, &ScrollPostExecutionContext)) -> Self {
+        // TODO(scroll): uncomment once use of the revm sdk pattern is adopted. Tracked in
+        // https://github.com/scroll-tech/reth/issues/97
+        // let context = context.get(&info.code_hash).copied();
+        // let (code_size, poseidon_code_hash) = context
+        //     .or_else(|| {
+        //         info.code
+        //             .as_ref()
+        //             .map(|code| (code.len() as u64, hash_code(code.original_byte_slice())))
+        //     })
+        //     .unwrap_or((0, POSEIDON_EMPTY));
         Self {
             balance: info.balance,
             nonce: info.nonce,
             code_hash: info.code_hash,
             code: info.code,
-            code_size,
-            poseidon_code_hash,
+            code_size: info.code_size as u64,
+            poseidon_code_hash: info.poseidon_code_hash,
         }
     }
 }

--- a/crates/scroll/revm/src/test_utils.rs
+++ b/crates/scroll/revm/src/test_utils.rs
@@ -1,9 +1,9 @@
 use crate::{
     shared::AccountInfo,
     states::{
-        ScrollAccountInfoRevert, ScrollAccountRevert, ScrollPlainStateReverts, ScrollStateChangeset,
+        ScrollAccountInfo, ScrollAccountInfoRevert, ScrollAccountRevert, ScrollPlainStateReverts,
+        ScrollStateChangeset,
     },
-    ScrollAccountInfo,
 };
 use reth_scroll_primitives::poseidon::{hash_code, POSEIDON_EMPTY};
 use revm::db::{


### PR DESCRIPTION
Comments the Poseidon code hashing of the account code hash. This should be uncommented once we replace the Scroll revm fork and adopt the sdk pattern introduced in revm.

Resolves #84 