### PR TITLE
Fix github actions timeout

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -232,7 +232,7 @@ jobs:
   features:
     name: features
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@clippy


### PR DESCRIPTION
The action to check features using cargo hack takes more than the 30 minute timeout that was originally set in the workflow. This PR increases the timeout to 60 minutes.