### PR TITLE
`scroll-reth` required features

### DIFF
--- a/crates/scroll/bin/scroll-reth/Cargo.toml
+++ b/crates/scroll/bin/scroll-reth/Cargo.toml
@@ -39,3 +39,4 @@ optimism = [
 [[bin]]
 name = "scroll-reth"
 path = "src/main.rs"
+required-features = ["scroll"]


### PR DESCRIPTION
This PR introduces `required-features = ["scroll"]` on the `scroll-reth` binary. This is because the BMPT requires the `scroll` feature flag to operate correctly. 

closes: #110 