### PR TITLE
fix: hardfork logging

### DIFF
--- a/crates/ethereum-forks/src/display.rs
+++ b/crates/ethereum-forks/src/display.rs
@@ -123,7 +123,7 @@ impl core::fmt::Display for DisplayHardforks {
         format(
             "Pre-merge hard forks (block based)",
             &self.pre_merge,
-            self.with_merge.is_empty(),
+            self.with_merge.is_empty() && self.post_merge.is_empty(),
             f,
         )?;
 


### PR DESCRIPTION
This PR fixes hardfork logging. The logic now checks both `with_merge` and `post_merge` hard forks to assess if `next_is_empty`. I will upstream this fix.

closes: #95 