### PR TITLE
fix: makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ install-op: ## Build and install the op-reth binary under `~/.cargo/bin`.
 
 .PHONY: install-scroll
 install-scroll: ## Build and install the scroll-reth binary under `~/.cargo/bin`.
-	cargo install --path crates/scroll/bin --bin scroll-reth --force --locked \
+	cargo install --path crates/scroll/bin/scroll-reth --bin scroll-reth --force --locked \
 		--features "scroll" \
 		--profile "$(PROFILE)" \
 		$(CARGO_INSTALL_EXTRA_FLAGS)


### PR DESCRIPTION
Fixes the `install-scroll` recipe.

Resolves #115 