### PR TITLE
feat: mpt feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9392,6 +9392,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-scroll-forks",
  "reth-scroll-state-commitment",
+ "reth-trie-common",
  "serde",
  "serde_json",
 ]

--- a/crates/scroll/bin/scroll-reth-mpt/Cargo.toml
+++ b/crates/scroll/bin/scroll-reth-mpt/Cargo.toml
@@ -18,8 +18,8 @@ reth-node-builder.workspace = true
 reth-provider.workspace = true
 
 # scroll
-reth-scroll-cli.workspace = true
-reth-scroll-node.workspace = true
+reth-scroll-cli = { workspace = true, features = ["mpt"]}
+reth-scroll-node = { workspace = true, features = ["mpt"] }
 
 # misc
 clap = { workspace = true, features = ["derive", "env"] }

--- a/crates/scroll/chainspec/Cargo.toml
+++ b/crates/scroll/chainspec/Cargo.toml
@@ -15,8 +15,9 @@ workspace = true
 # reth
 reth-chainspec.workspace = true
 reth-ethereum-forks.workspace = true
-reth-primitives-traits.workspace = true
 reth-network-peers.workspace = true
+reth-primitives-traits.workspace = true
+reth-trie-common = { workspace = true, optional = true }
 
 # scroll
 reth-scroll-forks.workspace = true
@@ -60,3 +61,4 @@ std = [
 	"derive_more/std",
 	"reth-network-peers/std"
 ]
+mpt = ["reth-trie-common"]

--- a/crates/scroll/chainspec/src/lib.rs
+++ b/crates/scroll/chainspec/src/lib.rs
@@ -233,7 +233,10 @@ impl ScrollChainSpec {
             difficulty: self.genesis.difficulty,
             nonce: self.genesis.nonce.into(),
             extra_data: self.genesis.extra_data.clone(),
+            #[cfg(not(feature = "mpt"))]
             state_root: reth_scroll_state_commitment::state_root_ref_unhashed(&self.genesis.alloc),
+            #[cfg(feature = "mpt")]
+            state_root: reth_trie_common::root::state_root_ref_unhashed(&self.genesis.alloc),
             timestamp: self.genesis.timestamp,
             mix_hash: self.genesis.mix_hash,
             beneficiary: self.genesis.coinbase,

--- a/crates/scroll/cli/Cargo.toml
+++ b/crates/scroll/cli/Cargo.toml
@@ -47,3 +47,4 @@ scroll = [
 	"reth-scroll-evm/scroll",
 	"reth-scroll-node/scroll"
 ]
+mpt = ["reth-scroll-chainspec/mpt"]

--- a/crates/scroll/node/Cargo.toml
+++ b/crates/scroll/node/Cargo.toml
@@ -64,4 +64,5 @@ scroll = [
 	"reth-scroll-evm/scroll",
 	"reth-scroll-engine/scroll"
 ]
+mpt = ["reth-scroll-chainspec/mpt"]
 skip-state-root-validation = []


### PR DESCRIPTION
Adds a `mpt` feature flag which allows to use the MPT for the computation of the genesis state root for the Scroll chain specification.