### PR TITLE
fix: sync ci

### DIFF
--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -126,4 +126,5 @@ test-utils = [
     "reth-trie-db/test-utils",
     "reth-trie-parallel/test-utils",
 ]
+scroll = []
 skip-state-root-validation = ["reth-stages/skip-state-root-validation"]

--- a/crates/engine/tree/benches/state_root_task.rs
+++ b/crates/engine/tree/benches/state_root_task.rs
@@ -103,6 +103,8 @@ fn convert_revm_to_reth_account(revm_account: &RevmAccount) -> Option<RethAccoun
             } else {
                 Some(revm_account.info.code_hash)
             },
+            #[cfg(feature = "scroll")]
+            code_size: revm_account.info.code_size as u64,
         }),
     }
 }

--- a/crates/engine/tree/src/tree/root.rs
+++ b/crates/engine/tree/src/tree/root.rs
@@ -855,6 +855,8 @@ mod tests {
             } else {
                 Some(revm_account.info.code_hash)
             },
+            #[cfg(feature = "scroll")]
+            code_size: revm_account.info.code_size as u64,
         }
     }
 

--- a/crates/ethereum/evm/src/execute.rs
+++ b/crates/ethereum/evm/src/execute.rs
@@ -350,6 +350,8 @@ mod tests {
             balance: U256::ZERO,
             bytecode_hash: Some(keccak256(BEACON_ROOTS_CODE.clone())),
             nonce: 1,
+            #[cfg(feature = "scroll")]
+            code_size: BEACON_ROOTS_CODE.len() as u64,
         };
 
         db.insert_account(
@@ -369,6 +371,8 @@ mod tests {
             nonce: 1,
             balance: U256::ZERO,
             bytecode_hash: Some(keccak256(WITHDRAWAL_REQUEST_PREDEPLOY_CODE.clone())),
+            #[cfg(feature = "scroll")]
+            code_size: WITHDRAWAL_REQUEST_PREDEPLOY_CODE.len() as u64,
         };
 
         db.insert_account(
@@ -674,6 +678,8 @@ mod tests {
             balance: U256::ZERO,
             bytecode_hash: Some(keccak256(HISTORY_STORAGE_CODE.clone())),
             nonce: 1,
+            #[cfg(feature = "scroll")]
+            code_size: HISTORY_STORAGE_CODE.len() as u64,
         };
 
         db.insert_account(
@@ -976,7 +982,13 @@ mod tests {
 
         db.insert_account(
             sender_address,
-            Account { nonce: 1, balance: U256::from(ETH_TO_WEI), bytecode_hash: None },
+            Account {
+                nonce: 1,
+                balance: U256::from(ETH_TO_WEI),
+                bytecode_hash: None,
+                #[cfg(feature = "scroll")]
+                code_size: 0,
+            },
             None,
             HashMap::default(),
         );
@@ -1051,7 +1063,13 @@ mod tests {
         // Insert the sender account into the state with a nonce of 1 and a balance of 1 ETH in Wei
         db.insert_account(
             sender_address,
-            Account { nonce: 1, balance: U256::from(ETH_TO_WEI), bytecode_hash: None },
+            Account {
+                nonce: 1,
+                balance: U256::from(ETH_TO_WEI),
+                bytecode_hash: None,
+                #[cfg(feature = "scroll")]
+                code_size: 0,
+            },
             None,
             HashMap::default(),
         );
@@ -1123,7 +1141,13 @@ mod tests {
         let initial_balance = 100;
         db.insert_account(
             withdrawal_recipient,
-            Account { balance: U256::from(initial_balance), nonce: 1, bytecode_hash: None },
+            Account {
+                balance: U256::from(initial_balance),
+                nonce: 1,
+                bytecode_hash: None,
+                #[cfg(feature = "scroll")]
+                code_size: 0,
+            },
             None,
             HashMap::default(),
         );

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -128,6 +128,7 @@ scroll = [
     "reth-blockchain-tree/scroll",
     "reth-rpc-eth-types/scroll",
     "reth-stages/scroll",
+    "reth-db-common/scroll",
     "reth-invalid-block-hooks/scroll"
 ]
 skip-state-root-validation = [

--- a/crates/primitives-traits/src/account.rs
+++ b/crates/primitives-traits/src/account.rs
@@ -37,6 +37,9 @@ pub struct Account {
     pub balance: U256,
     /// Hash of the account's bytecode.
     pub bytecode_hash: Option<B256>,
+    /// The code size of the account
+    #[cfg(feature = "scroll")]
+    pub code_size: u64,
 }
 
 impl Account {
@@ -61,7 +64,7 @@ impl Account {
 
     /// Converts the account into a trie account with the given storage root.
     pub fn into_trie_account(self, storage_root: B256) -> TrieAccount {
-        let Self { nonce, balance, bytecode_hash } = self;
+        let Self { nonce, balance, bytecode_hash, .. } = self;
         TrieAccount {
             nonce,
             balance,
@@ -184,6 +187,8 @@ impl From<&GenesisAccount> for Account {
             nonce: value.nonce.unwrap_or_default(),
             balance: value.balance,
             bytecode_hash: value.code.as_ref().map(keccak256),
+            #[cfg(feature = "scroll")]
+            code_size: value.code.as_ref().map(|c| c.len() as u64).unwrap_or_default(),
         }
     }
 }
@@ -194,6 +199,8 @@ impl From<AccountInfo> for Account {
             balance: revm_acc.balance,
             nonce: revm_acc.nonce,
             bytecode_hash: (!revm_acc.is_empty_code_hash()).then_some(revm_acc.code_hash),
+            #[cfg(feature = "scroll")]
+            code_size: revm_acc.code_size as u64,
         }
     }
 }
@@ -204,6 +211,8 @@ impl From<&AccountInfo> for Account {
             balance: revm_acc.balance,
             nonce: revm_acc.nonce,
             bytecode_hash: (!revm_acc.is_empty_code_hash()).then_some(revm_acc.code_hash),
+            #[cfg(feature = "scroll")]
+            code_size: revm_acc.code_size as u64,
         }
     }
 }
@@ -216,7 +225,7 @@ impl From<Account> for AccountInfo {
             code_hash: reth_acc.bytecode_hash.unwrap_or(KECCAK_EMPTY),
             code: None,
             #[cfg(feature = "scroll")]
-            code_size: 0,
+            code_size: reth_acc.code_size as usize,
             #[cfg(feature = "scroll")]
             poseidon_code_hash: Default::default(),
         }
@@ -249,7 +258,13 @@ mod tests {
 
     #[test]
     fn test_empty_account() {
-        let mut acc = Account { nonce: 0, balance: U256::ZERO, bytecode_hash: None };
+        let mut acc = Account {
+            nonce: 0,
+            balance: U256::ZERO,
+            bytecode_hash: None,
+            #[cfg(feature = "scroll")]
+            code_size: 0,
+        };
         // Nonce 0, balance 0, and bytecode hash set to None is considered empty.
         assert!(acc.is_empty());
 
@@ -301,12 +316,23 @@ mod tests {
     #[test]
     fn test_account_has_bytecode() {
         // Account with no bytecode (None)
-        let acc_no_bytecode = Account { nonce: 1, balance: U256::from(1000), bytecode_hash: None };
+        let acc_no_bytecode = Account {
+            nonce: 1,
+            balance: U256::from(1000),
+            bytecode_hash: None,
+            #[cfg(feature = "scroll")]
+            code_size: 0,
+        };
         assert!(!acc_no_bytecode.has_bytecode(), "Account should not have bytecode");
 
         // Account with bytecode hash set to KECCAK_EMPTY (should have bytecode)
-        let acc_empty_bytecode =
-            Account { nonce: 1, balance: U256::from(1000), bytecode_hash: Some(KECCAK_EMPTY) };
+        let acc_empty_bytecode = Account {
+            nonce: 1,
+            balance: U256::from(1000),
+            bytecode_hash: Some(KECCAK_EMPTY),
+            #[cfg(feature = "scroll")]
+            code_size: 0,
+        };
         assert!(acc_empty_bytecode.has_bytecode(), "Account should have bytecode");
 
         // Account with a non-empty bytecode hash
@@ -314,6 +340,8 @@ mod tests {
             nonce: 1,
             balance: U256::from(1000),
             bytecode_hash: Some(B256::from_slice(&[0x11u8; 32])),
+            #[cfg(feature = "scroll")]
+            code_size: 32,
         };
         assert!(acc_with_bytecode.has_bytecode(), "Account should have bytecode");
     }
@@ -321,12 +349,23 @@ mod tests {
     #[test]
     fn test_account_get_bytecode_hash() {
         // Account with no bytecode (should return KECCAK_EMPTY)
-        let acc_no_bytecode = Account { nonce: 0, balance: U256::ZERO, bytecode_hash: None };
+        let acc_no_bytecode = Account {
+            nonce: 0,
+            balance: U256::ZERO,
+            bytecode_hash: None,
+            #[cfg(feature = "scroll")]
+            code_size: 0,
+        };
         assert_eq!(acc_no_bytecode.get_bytecode_hash(), KECCAK_EMPTY, "Should return KECCAK_EMPTY");
 
         // Account with bytecode hash set to KECCAK_EMPTY
-        let acc_empty_bytecode =
-            Account { nonce: 1, balance: U256::from(1000), bytecode_hash: Some(KECCAK_EMPTY) };
+        let acc_empty_bytecode = Account {
+            nonce: 1,
+            balance: U256::from(1000),
+            bytecode_hash: Some(KECCAK_EMPTY),
+            #[cfg(feature = "scroll")]
+            code_size: 0,
+        };
         assert_eq!(
             acc_empty_bytecode.get_bytecode_hash(),
             KECCAK_EMPTY,
@@ -335,8 +374,13 @@ mod tests {
 
         // Account with a valid bytecode hash
         let bytecode_hash = B256::from_slice(&[0x11u8; 32]);
-        let acc_with_bytecode =
-            Account { nonce: 1, balance: U256::from(1000), bytecode_hash: Some(bytecode_hash) };
+        let acc_with_bytecode = Account {
+            nonce: 1,
+            balance: U256::from(1000),
+            bytecode_hash: Some(bytecode_hash),
+            #[cfg(feature = "scroll")]
+            code_size: 32,
+        };
         assert_eq!(
             acc_with_bytecode.get_bytecode_hash(),
             bytecode_hash,

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -865,13 +865,25 @@ mod tests {
         db_tx
             .put::<tables::PlainAccountState>(
                 acc1,
-                Account { nonce: 0, balance: U256::ZERO, bytecode_hash: Some(code_hash) },
+                Account {
+                    nonce: 0,
+                    balance: U256::ZERO,
+                    bytecode_hash: Some(code_hash),
+                    #[cfg(feature = "scroll")]
+                    code_size: code.len() as u64,
+                },
             )
             .unwrap();
         db_tx
             .put::<tables::PlainAccountState>(
                 acc2,
-                Account { nonce: 0, balance, bytecode_hash: None },
+                Account {
+                    nonce: 0,
+                    balance,
+                    bytecode_hash: None,
+                    #[cfg(feature = "scroll")]
+                    code_size: 0,
+                },
             )
             .unwrap();
         db_tx.put::<tables::Bytecodes>(code_hash, Bytecode::new_raw(code.to_vec().into())).unwrap();
@@ -922,19 +934,28 @@ mod tests {
 
             // check post state
             let account1 = address!("1000000000000000000000000000000000000000");
-            let account1_info =
-                Account { balance: U256::ZERO, nonce: 0x00, bytecode_hash: Some(code_hash) };
+            let account1_info = Account {
+                balance: U256::ZERO,
+                nonce: 0x00,
+                bytecode_hash: Some(code_hash),
+                #[cfg(feature = "scroll")]
+                code_size: code.len() as u64,
+            };
             let account2 = address!("2adc25665018aa1fe0e6bc666dac8fc2697ff9ba");
             let account2_info = Account {
                 balance: U256::from(0x1bc16d674ece94bau128),
                 nonce: 0x00,
                 bytecode_hash: None,
+                #[cfg(feature = "scroll")]
+                code_size: 0,
             };
             let account3 = address!("a94f5374fce5edbc8e2a8697c15331677e6ebf0b");
             let account3_info = Account {
                 balance: U256::from(0x3635c9adc5de996b46u128),
                 nonce: 0x01,
                 bytecode_hash: None,
+                #[cfg(feature = "scroll")]
+                code_size: 0,
             };
 
             // assert accounts
@@ -1011,9 +1032,21 @@ mod tests {
 
         let db_tx = provider.tx_ref();
         let acc1 = address!("1000000000000000000000000000000000000000");
-        let acc1_info = Account { nonce: 0, balance: U256::ZERO, bytecode_hash: Some(code_hash) };
+        let acc1_info = Account {
+            nonce: 0,
+            balance: U256::ZERO,
+            bytecode_hash: Some(code_hash),
+            #[cfg(feature = "scroll")]
+            code_size: code.len() as u64,
+        };
         let acc2 = address!("a94f5374fce5edbc8e2a8697c15331677e6ebf0b");
-        let acc2_info = Account { nonce: 0, balance, bytecode_hash: None };
+        let acc2_info = Account {
+            nonce: 0,
+            balance,
+            bytecode_hash: None,
+            #[cfg(feature = "scroll")]
+            code_size: 0,
+        };
 
         db_tx.put::<tables::PlainAccountState>(acc1, acc1_info).unwrap();
         db_tx.put::<tables::PlainAccountState>(acc2, acc2_info).unwrap();
@@ -1132,9 +1165,20 @@ mod tests {
         let code_hash = keccak256(code);
 
         // pre state
-        let caller_info = Account { nonce: 0, balance, bytecode_hash: None };
-        let destroyed_info =
-            Account { nonce: 0, balance: U256::ZERO, bytecode_hash: Some(code_hash) };
+        let caller_info = Account {
+            nonce: 0,
+            balance,
+            bytecode_hash: None,
+            #[cfg(feature = "scroll")]
+            code_size: 0,
+        };
+        let destroyed_info = Account {
+            nonce: 0,
+            balance: U256::ZERO,
+            bytecode_hash: Some(code_hash),
+            #[cfg(feature = "scroll")]
+            code_size: code.len() as u64,
+        };
 
         // set account
         let provider = test_db.factory.provider_rw().unwrap();
@@ -1193,7 +1237,9 @@ mod tests {
                     Account {
                         nonce: 0,
                         balance: U256::from(0x1bc16d674eca30a0u64),
-                        bytecode_hash: None
+                        bytecode_hash: None,
+                        #[cfg(feature = "scroll")]
+                        code_size: 0,
                     }
                 ),
                 (
@@ -1201,7 +1247,9 @@ mod tests {
                     Account {
                         nonce: 1,
                         balance: U256::from(0xde0b6b3a761cf60u64),
-                        bytecode_hash: None
+                        bytecode_hash: None,
+                        #[cfg(feature = "scroll")]
+                        code_size: 0,
                     }
                 )
             ]

--- a/crates/stages/stages/src/stages/hashing_account.rs
+++ b/crates/stages/stages/src/stages/hashing_account.rs
@@ -115,6 +115,8 @@ impl AccountHashingStage {
                     nonce: nonce - 1,
                     balance: balance - U256::from(1),
                     bytecode_hash: None,
+                    #[cfg(feature = "scroll")]
+                    code_size: 0,
                 };
                 let acc_before_tx = AccountBeforeTx { address: *addr, info: Some(prev_acc) };
                 acc_changeset_cursor.append(t, acc_before_tx)?;
@@ -420,6 +422,8 @@ mod tests {
                             nonce: nonce - 1,
                             balance: balance - U256::from(1),
                             bytecode_hash: None,
+                            #[cfg(feature = "scroll")]
+                            code_size: 0,
                         };
                         let hashed_addr = keccak256(address);
                         if let Some((_, acc)) = hashed_acc_cursor.seek_exact(hashed_addr)? {

--- a/crates/stages/stages/src/stages/mod.rs
+++ b/crates/stages/stages/src/stages/mod.rs
@@ -118,7 +118,13 @@ mod tests {
             .tx_ref()
             .put::<tables::PlainAccountState>(
                 address!("1000000000000000000000000000000000000000"),
-                Account { nonce: 0, balance: U256::ZERO, bytecode_hash: Some(code_hash) },
+                Account {
+                    nonce: 0,
+                    balance: U256::ZERO,
+                    bytecode_hash: Some(code_hash),
+                    #[cfg(feature = "scroll")]
+                    code_size: code.len() as u64,
+                },
             )
             .unwrap();
         provider_rw
@@ -129,6 +135,8 @@ mod tests {
                     nonce: 0,
                     balance: U256::from(0x3635c9adc5dea00000u128),
                     bytecode_hash: None,
+                    #[cfg(feature = "scroll")]
+                    code_size: 0,
                 },
             )
             .unwrap();

--- a/crates/storage/db-common/Cargo.toml
+++ b/crates/storage/db-common/Cargo.toml
@@ -47,3 +47,6 @@ alloy-consensus.workspace = true
 
 [lints]
 workspace = true
+
+[features]
+scroll = []

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -234,6 +234,8 @@ where
                     nonce: account.nonce.unwrap_or_default(),
                     balance: account.balance,
                     bytecode_hash,
+                    #[cfg(feature = "scroll")]
+                    code_size: account.code.as_ref().map(|c| c.len() as u64).unwrap_or_default(),
                 }),
                 storage,
             ),

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -1180,6 +1180,8 @@ mod tests {
             nonce: 18446744073709551615,
             bytecode_hash: Some(B256::random()),
             balance: U256::MAX,
+            #[cfg(feature = "scroll")]
+            code_size: 0,
         };
         let key = Address::from_str("0xa2c122be93b0074270ebee7f6b7292c7deb45047")
             .expect(ERROR_ETH_ADDRESS);

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -624,13 +624,49 @@ mod tests {
         )
         .unwrap();
 
-        let acc_plain = Account { nonce: 100, balance: U256::ZERO, bytecode_hash: None };
-        let acc_at15 = Account { nonce: 15, balance: U256::ZERO, bytecode_hash: None };
-        let acc_at10 = Account { nonce: 10, balance: U256::ZERO, bytecode_hash: None };
-        let acc_at7 = Account { nonce: 7, balance: U256::ZERO, bytecode_hash: None };
-        let acc_at3 = Account { nonce: 3, balance: U256::ZERO, bytecode_hash: None };
+        let acc_plain = Account {
+            nonce: 100,
+            balance: U256::ZERO,
+            bytecode_hash: None,
+            #[cfg(feature = "scroll")]
+            code_size: 0,
+        };
+        let acc_at15 = Account {
+            nonce: 15,
+            balance: U256::ZERO,
+            bytecode_hash: None,
+            #[cfg(feature = "scroll")]
+            code_size: 0,
+        };
+        let acc_at10 = Account {
+            nonce: 10,
+            balance: U256::ZERO,
+            bytecode_hash: None,
+            #[cfg(feature = "scroll")]
+            code_size: 0,
+        };
+        let acc_at7 = Account {
+            nonce: 7,
+            balance: U256::ZERO,
+            bytecode_hash: None,
+            #[cfg(feature = "scroll")]
+            code_size: 0,
+        };
+        let acc_at3 = Account {
+            nonce: 3,
+            balance: U256::ZERO,
+            bytecode_hash: None,
+            #[cfg(feature = "scroll")]
+            code_size: 0,
+        };
 
-        let higher_acc_plain = Account { nonce: 4, balance: U256::ZERO, bytecode_hash: None };
+        let higher_acc_plain = Account {
+            nonce: 4,
+            balance: U256::ZERO,
+            bytecode_hash: None,
+            #[cfg(feature = "scroll")]
+            code_size: 0,
+        };
 
         // setup
         tx.put::<tables::AccountChangeSets>(1, AccountBeforeTx { address: ADDRESS, info: None })

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -83,7 +83,13 @@ impl ExtendedAccount {
     /// Create new instance of extended account
     pub fn new(nonce: u64, balance: U256) -> Self {
         Self {
-            account: Account { nonce, balance, bytecode_hash: None },
+            account: Account {
+                nonce,
+                balance,
+                bytecode_hash: None,
+                #[cfg(feature = "scroll")]
+                code_size: 0,
+            },
             bytecode: None,
             storage: Default::default(),
         }

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -1085,7 +1085,13 @@ mod tests {
         type PreState = BTreeMap<Address, (Account, BTreeMap<B256, U256>)>;
         let mut prestate: PreState = (0..10)
             .map(|key| {
-                let account = Account { nonce: 1, balance: U256::from(key), bytecode_hash: None };
+                let account = Account {
+                    nonce: 1,
+                    balance: U256::from(key),
+                    bytecode_hash: None,
+                    #[cfg(feature = "scroll")]
+                    code_size: 0,
+                };
                 let storage =
                     (1..11).map(|key| (B256::with_last_byte(key), U256::from(key))).collect();
                 (Address::with_last_byte(key), (account, storage))
@@ -1210,8 +1216,13 @@ mod tests {
         assert_state_root(&state, &prestate, "changed nonce");
 
         // recreate account 1
-        let account1_new =
-            Account { nonce: 56, balance: U256::from(123), bytecode_hash: Some(B256::random()) };
+        let account1_new = Account {
+            nonce: 56,
+            balance: U256::from(123),
+            bytecode_hash: Some(B256::random()),
+            #[cfg(feature = "scroll")]
+            code_size: 0,
+        };
         prestate.insert(address1, (account1_new, BTreeMap::default()));
         state.commit(HashMap::from_iter([(
             address1,

--- a/crates/trie/common/Cargo.toml
+++ b/crates/trie/common/Cargo.toml
@@ -119,6 +119,7 @@ arbitrary = [
 	"reth-codecs/arbitrary",
 	"alloy-rpc-types-eth?/arbitrary",
 ]
+scroll = ["reth-primitives-traits/scroll"]
 
 [[bench]]
 name = "prefix_set"

--- a/crates/trie/common/src/account.rs
+++ b/crates/trie/common/src/account.rs
@@ -63,7 +63,9 @@ mod tests {
             Account {
                 nonce: 10,
                 balance: U256::from(1000),
-                bytecode_hash: Some(keccak256([0x60, 0x61]))
+                bytecode_hash: Some(keccak256([0x60, 0x61])),
+                #[cfg(feature = "scroll")]
+                code_size: 2
             }
             .into_trie_account(expected_storage_root),
             trie_account

--- a/crates/trie/common/src/proofs.rs
+++ b/crates/trie/common/src/proofs.rs
@@ -87,6 +87,9 @@ impl MultiProof {
                             nonce: account.nonce,
                             bytecode_hash: (account.code_hash != KECCAK_EMPTY)
                                 .then_some(account.code_hash),
+                            // TODO (scroll): set the code size to the correct value.
+                            #[cfg(feature = "scroll")]
+                            code_size: 0,
                         })
                     }
                 }

--- a/crates/trie/db/Cargo.toml
+++ b/crates/trie/db/Cargo.toml
@@ -92,6 +92,7 @@ test-utils = [
 scroll = [
 	"reth-db/scroll",
 	"reth-primitives/scroll",
+	"reth-trie-common/scroll",
 	"reth-provider/scroll",
 	"revm/scroll"
 ]

--- a/crates/trie/db/tests/proof.rs
+++ b/crates/trie/db/tests/proof.rs
@@ -198,7 +198,9 @@ fn holesky_deposit_contract_proof() {
         info:  Some(Account {
             balance: U256::ZERO,
             nonce: 0,
-            bytecode_hash: Some(B256::from_str("0x2034f79e0e33b0ae6bef948532021baceb116adf2616478703bec6b17329f1cc").unwrap())
+            bytecode_hash: Some(B256::from_str("0x2034f79e0e33b0ae6bef948532021baceb116adf2616478703bec6b17329f1cc").unwrap()),
+            #[cfg(feature = "scroll")]
+            code_size: 12,
         }),
         storage_root: B256::from_str("0x556a482068355939c95a3412bdb21213a301483edb1b64402fb66ac9f3583599").unwrap(),
         proof: convert_to_proof([

--- a/crates/trie/db/tests/trie.rs
+++ b/crates/trie/db/tests/trie.rs
@@ -137,14 +137,26 @@ fn test_empty_account() {
         (
             Address::random(),
             (
-                Account { nonce: 0, balance: U256::from(0), bytecode_hash: None },
+                Account {
+                    nonce: 0,
+                    balance: U256::from(0),
+                    bytecode_hash: None,
+                    #[cfg(feature = "scroll")]
+                    code_size: 0,
+                },
                 BTreeMap::from([(B256::with_last_byte(0x4), U256::from(12))]),
             ),
         ),
         (
             Address::random(),
             (
-                Account { nonce: 0, balance: U256::from(0), bytecode_hash: None },
+                Account {
+                    nonce: 0,
+                    balance: U256::from(0),
+                    bytecode_hash: None,
+                    #[cfg(feature = "scroll")]
+                    code_size: 0,
+                },
                 BTreeMap::default(),
             ),
         ),
@@ -155,6 +167,8 @@ fn test_empty_account() {
                     nonce: 155,
                     balance: U256::from(414241124u32),
                     bytecode_hash: Some(keccak256("test")),
+                    #[cfg(feature = "scroll")]
+                    code_size: 12,
                 },
                 BTreeMap::from([
                     (B256::ZERO, U256::from(3)),
@@ -178,6 +192,8 @@ fn test_empty_storage_root() {
         nonce: 155,
         balance: U256::from(414241124u32),
         bytecode_hash: Some(keccak256(code)),
+        #[cfg(feature = "scroll")]
+        code_size: code.len() as u64,
     };
     insert_account(tx.tx_ref(), address, account, &Default::default());
     tx.commit().unwrap();
@@ -202,6 +218,8 @@ fn test_storage_root() {
         nonce: 155,
         balance: U256::from(414241124u32),
         bytecode_hash: Some(keccak256(code)),
+        #[cfg(feature = "scroll")]
+        code_size: code.len() as u64,
     };
 
     insert_account(tx.tx_ref(), address, account, &storage);
@@ -348,7 +366,13 @@ fn account_and_storage_trie() {
     // Insert first account
     let key1 =
         B256::from_str("b000000000000000000000000000000000000000000000000000000000000000").unwrap();
-    let account1 = Account { nonce: 0, balance: U256::from(3).mul(ether), bytecode_hash: None };
+    let account1 = Account {
+        nonce: 0,
+        balance: U256::from(3).mul(ether),
+        bytecode_hash: None,
+        #[cfg(feature = "scroll")]
+        code_size: 0,
+    };
     hashed_account_cursor.upsert(key1, account1).unwrap();
     hash_builder.add_leaf(Nibbles::unpack(key1), &encode_account(account1, None));
 
@@ -368,8 +392,13 @@ fn account_and_storage_trie() {
     assert_eq!(key3[1], 0x41);
     let code_hash =
         B256::from_str("5be74cad16203c4905c068b012a2e9fb6d19d036c410f16fd177f337541440dd").unwrap();
-    let account3 =
-        Account { nonce: 0, balance: U256::from(2).mul(ether), bytecode_hash: Some(code_hash) };
+    let account3 = Account {
+        nonce: 0,
+        balance: U256::from(2).mul(ether),
+        bytecode_hash: Some(code_hash),
+        #[cfg(feature = "scroll")]
+        code_size: 12,
+    };
     hashed_account_cursor.upsert(key3, account3).unwrap();
     for (hashed_slot, value) in storage {
         if hashed_storage_cursor
@@ -451,7 +480,13 @@ fn account_and_storage_trie() {
     let address4b = Address::from_str("4f61f2d5ebd991b85aa1677db97307caf5215c91").unwrap();
     let key4b = keccak256(address4b);
     assert_eq!(key4b.0[0], key4a.0[0]);
-    let account4b = Account { nonce: 0, balance: U256::from(5).mul(ether), bytecode_hash: None };
+    let account4b = Account {
+        nonce: 0,
+        balance: U256::from(5).mul(ether),
+        bytecode_hash: None,
+        #[cfg(feature = "scroll")]
+        code_size: 0,
+    };
     hashed_account_cursor.upsert(key4b, account4b).unwrap();
 
     let mut prefix_set = PrefixSetMut::default();
@@ -716,7 +751,13 @@ fn extension_node_storage_trie<N: ProviderNodeTypes>(
 fn extension_node_trie<N: ProviderNodeTypes>(
     tx: &DatabaseProviderRW<Arc<TempDatabase<DatabaseEnv>>, N>,
 ) -> B256 {
-    let a = Account { nonce: 0, balance: U256::from(1u64), bytecode_hash: Some(B256::random()) };
+    let a = Account {
+        nonce: 0,
+        balance: U256::from(1u64),
+        bytecode_hash: Some(B256::random()),
+        #[cfg(feature = "scroll")]
+        code_size: 12,
+    };
     let val = encode_account(a, None);
 
     let mut hashed_accounts = tx.tx_ref().cursor_write::<tables::HashedAccounts>().unwrap();

--- a/crates/trie/trie/Cargo.toml
+++ b/crates/trie/trie/Cargo.toml
@@ -81,7 +81,10 @@ test-utils = [
     "reth-stages-types/test-utils",
     "reth-primitives-traits/test-utils"
 ]
-scroll = ["revm/scroll"]
+scroll = [
+    "revm/scroll",
+    "reth-trie-common/scroll"
+]
 
 [[bench]]
 name = "hash_post_state"

--- a/testing/ef-tests/src/models.rs
+++ b/testing/ef-tests/src/models.rs
@@ -164,6 +164,8 @@ impl State {
                 balance: account.balance,
                 nonce: account.nonce.to::<u64>(),
                 bytecode_hash: code_hash,
+                #[cfg(feature = "scroll")]
+                code_size: account.code.len() as u64,
             };
             tx.put::<tables::PlainAccountState>(address, reth_account)?;
             tx.put::<tables::HashedAccounts>(hashed_address, reth_account)?;

--- a/testing/testing-utils/src/generators.rs
+++ b/testing/testing-utils/src/generators.rs
@@ -403,7 +403,16 @@ pub fn random_eoa_account<R: Rng>(rng: &mut R) -> (Address, Account) {
     let balance = U256::from(rng.gen::<u32>());
     let addr = rng.gen();
 
-    (addr, Account { nonce, balance, bytecode_hash: None })
+    (
+        addr,
+        Account {
+            nonce,
+            balance,
+            bytecode_hash: None,
+            #[cfg(feature = "scroll")]
+            code_size: 0,
+        },
+    )
 }
 
 /// Generate random Externally Owned Accounts


### PR DESCRIPTION
The syncing of the Scroll node was failing due to a gas used mismatch itself stemming from the removal of the `code_size` on the `reth-primitives-traits::Account`.

The `code_size` is used in [extcodesize](https://github.com/scroll-tech/revm/blob/5cdeabaddd7fffa153e39de689d998a739eb404a/crates/interpreter/src/instructions/host.rs#L66), and removing it from the `Account` lead to a default value value of `0` to be used for the field when retrieving an account from database and converting it to an `revm::primitives::AccountInfo`. This further lead to a sync error (gas used mismatach) at block 3404 because an incorrect code size of 0 was used.