### PR TITLE
chore: fix mpt sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "19.0.0"
-source = "git+https://github.com/scroll-tech/revm.git?branch=scroll-evm-executor/reth/v51#5cdeabaddd7fffa153e39de689d998a739eb404a"
+source = "git+https://github.com/scroll-tech/revm.git?branch=scroll-evm-executor/reth/v51#73610d7435b592c40e25b7ffe2000320c42b7f5f"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -9913,7 +9913,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "15.0.0"
-source = "git+https://github.com/scroll-tech/revm.git?branch=scroll-evm-executor/reth/v51#5cdeabaddd7fffa153e39de689d998a739eb404a"
+source = "git+https://github.com/scroll-tech/revm.git?branch=scroll-evm-executor/reth/v51#73610d7435b592c40e25b7ffe2000320c42b7f5f"
 dependencies = [
  "cfg-if",
  "revm-primitives",
@@ -9923,7 +9923,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "16.0.0"
-source = "git+https://github.com/scroll-tech/revm.git?branch=scroll-evm-executor/reth/v51#5cdeabaddd7fffa153e39de689d998a739eb404a"
+source = "git+https://github.com/scroll-tech/revm.git?branch=scroll-evm-executor/reth/v51#73610d7435b592c40e25b7ffe2000320c42b7f5f"
 dependencies = [
  "aurora-engine-modexp",
  "blst",
@@ -9942,7 +9942,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "15.1.0"
-source = "git+https://github.com/scroll-tech/revm.git?branch=scroll-evm-executor/reth/v51#5cdeabaddd7fffa153e39de689d998a739eb404a"
+source = "git+https://github.com/scroll-tech/revm.git?branch=scroll-evm-executor/reth/v51#73610d7435b592c40e25b7ffe2000320c42b7f5f"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",


### PR DESCRIPTION
The `code_size` is used in [extcodesize](https://github.com/scroll-tech/revm/blob/5cdeabaddd7fffa153e39de689d998a739eb404a/crates/interpreter/src/instructions/host.rs#L66), and removing it from the `Account` lead to a default value value of `0` to be used for the field when retrieving an account from database and converting it to an `revm::primitives::AccountInfo`. This further lead to a sync error (gas used mismatch) at block 3404 because an incorrect code size of 0 was used.

In order to reenable syncing in the MPT mode without adding too much diff with upstream, we remove the `code_size` ["shortcut"](https://github.com/scroll-tech/revm/blob/9df25c5085f9ca477944b52bca972a6c920bcc8d/crates/interpreter/src/instructions/host.rs#L69) that is taken in the Scroll revm fork for the `extcodesize`, and instead retrieve the code from database and return its length as done in the latest [commit](https://github.com/scroll-tech/revm/blob/scroll-evm-executor/reth/v51/crates/interpreter/src/instructions/host.rs#L65) on the `scroll-evm-executor/reth/v51` branch.

Resolves #130 