### PR TITLE
fix: sync ci unwinding

### DIFF
--- a/crates/scroll/bin/scroll-reth/Cargo.toml
+++ b/crates/scroll/bin/scroll-reth/Cargo.toml
@@ -31,7 +31,8 @@ scroll = [
 ]
 skip-state-root-validation = [
 	"reth-node-builder/skip-state-root-validation",
-	"reth-scroll-node/skip-state-root-validation"
+	"reth-scroll-node/skip-state-root-validation",
+	"reth-provider/skip-state-root-validation"
 ]
 optimism = [
 	"reth-provider/optimism",

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -145,3 +145,4 @@ scroll = [
     "reth-execution-types/scroll",
     "reth-evm/scroll",
 ]
+skip-state-root-validation = []

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -321,8 +321,15 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             .ok_or_else(|| ProviderError::HeaderNotFound(parent_number.into()))?
             .state_root();
 
+        #[cfg(feature = "skip-state-root-validation")]
+        {
+            let _ = parent_state_root;
+            debug!(target: "provider::db::unwind", ?new_state_root, block_number = parent_number);
+        }
+
         // state root should be always correct as we are reverting state.
         // but for sake of double verification we will check it again.
+        #[cfg(not(feature = "skip-state-root-validation"))]
         if new_state_root != parent_state_root {
             let parent_hash = self
                 .block_hash(parent_number)?


### PR DESCRIPTION
Removes the state root validation when unwinding to a block.

Resolves #134 