### PR TITLE
fix: estimate gas

### DIFF
--- a/crates/scroll/rpc/src/eth/call.rs
+++ b/crates/scroll/rpc/src/eth/call.rs
@@ -7,7 +7,7 @@ use reth_rpc_eth_api::{
     FromEthApiError, FullEthApiTypes, IntoEthApiError,
 };
 use reth_rpc_eth_types::{revm_utils::CallFees, RpcInvalidTransactionError};
-use revm::primitives::{BlockEnv, TxEnv};
+use revm::primitives::{BlockEnv, ScrollFields, TxEnv};
 
 use super::ScrollNodeCore;
 use crate::{ScrollEthApi, ScrollEthApiError};
@@ -102,7 +102,7 @@ where
             blob_hashes: blob_versioned_hashes.unwrap_or_default(),
             max_fee_per_blob_gas,
             authorization_list: authorization_list.map(Into::into),
-            scroll: Default::default(),
+            scroll: ScrollFields { is_l1_msg: false, rlp_bytes: Some(Default::default()) },
         };
 
         Ok(env)


### PR DESCRIPTION
Fixes the gas estimation related to a missing `ScrollFields`. Resolves #137.
```shell
curl http://127.0.0.1:8545 -X POST -H "Content-Type: application/json"  --data '{"method":"eth_estimateGas","params":[{"to":"0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0"}],"id":1,"jsonrpc":"2.0"}'
{"jsonrpc":"2.0","id":1,"result":"0x5208"}
```