### PR TITLE
feat: scroll primitives

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -43,7 +43,7 @@ jobs:
             partition: 2
             total_partitions: 2
           - type: scroll
-            args: -p "reth-scroll-*" --locked --features "scroll"
+            args: -p "reth-scroll-*" -p "scroll-alloy-*" --locked --features "scroll"
             partition: 1
             total_partitions: 1
           - type: book

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9227,6 +9227,7 @@ dependencies = [
  "reth-scroll-chainspec",
  "reth-scroll-engine",
  "reth-scroll-evm",
+ "reth-scroll-primitives",
  "reth-scroll-rpc",
  "reth-tracing",
  "reth-transaction-pool",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9227,7 +9227,6 @@ dependencies = [
  "reth-scroll-chainspec",
  "reth-scroll-engine",
  "reth-scroll-evm",
- "reth-scroll-primitives",
  "reth-scroll-rpc",
  "reth-tracing",
  "reth-transaction-pool",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8641,6 +8641,7 @@ dependencies = [
  "rayon",
  "reth-codecs",
  "revm-primitives",
+ "scroll-alloy-consensus",
  "secp256k1",
  "serde",
  "serde_json",
@@ -9226,10 +9227,37 @@ dependencies = [
  "reth-scroll-chainspec",
  "reth-scroll-engine",
  "reth-scroll-evm",
+ "reth-scroll-primitives",
  "reth-scroll-rpc",
  "reth-tracing",
  "reth-transaction-pool",
  "reth-trie-db",
+]
+
+[[package]]
+name = "reth-scroll-primitives"
+version = "1.1.5"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "arbitrary",
+ "bytes",
+ "derive_more",
+ "modular-bitfield",
+ "once_cell",
+ "proptest",
+ "proptest-arbitrary-interop",
+ "rand 0.8.5",
+ "reth-codecs",
+ "reth-primitives-traits",
+ "reth-zstd-compressors",
+ "revm-primitives",
+ "rstest",
+ "scroll-alloy-consensus",
+ "secp256k1",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ members = [
     "crates/scroll/evm",
     "crates/scroll/hardforks",
     "crates/scroll/node",
+    "crates/scroll/primitives",
     "crates/scroll/rpc",
     "crates/scroll/trie",
     "crates/stages/api/",
@@ -493,8 +494,9 @@ reth-scroll-evm = { path = "crates/scroll/evm" }
 reth-scroll-engine = { path = "crates/scroll/engine" }
 reth-scroll-forks = { path = "crates/scroll/hardforks" }
 reth-scroll-node = { path = "crates/scroll/node" }
-reth-scroll-trie = { path = "crates/scroll/trie" }
+reth-scroll-primitives = { path = "crates/scroll/primitives" }
 reth-scroll-rpc = { path = "crates/scroll/rpc" }
+reth-scroll-trie = { path = "crates/scroll/trie" }
 # TODO (scroll): point to crates.io/tag once the crate is published/a tag is created.
 poseidon-bn254 = { git = "https://github.com/scroll-tech/poseidon-bn254", rev = "526a64a", features = ["bn254"] }
 

--- a/crates/exex/exex/src/context.rs
+++ b/crates/exex/exex/src/context.rs
@@ -21,7 +21,7 @@ pub struct ExExContext<Node: FullNodeComponents> {
     /// # Important
     ///
     /// The exex should emit a `FinishedHeight` whenever a processed block is safe to prune.
-    /// Additionally, the exex can pre-emptively emit a `FinishedHeight` event to specify what
+    /// Additionally, the exex can preemptively emit a `FinishedHeight` event to specify what
     /// blocks to receive notifications for.
     pub events: UnboundedSender<ExExEvent>,
     /// Channel to receive [`ExExNotification`](crate::ExExNotification)s.

--- a/crates/exex/exex/src/dyn_context.rs
+++ b/crates/exex/exex/src/dyn_context.rs
@@ -26,7 +26,7 @@ pub struct ExExContextDyn<N: NodePrimitives = EthPrimitives> {
     /// # Important
     ///
     /// The exex should emit a `FinishedHeight` whenever a processed block is safe to prune.
-    /// Additionally, the exex can pre-emptively emit a `FinishedHeight` event to specify what
+    /// Additionally, the exex can preemptively emit a `FinishedHeight` event to specify what
     /// blocks to receive notifications for.
     pub events: mpsc::UnboundedSender<ExExEvent>,
     /// Channel to receive [`ExExNotification`](crate::ExExNotification)s.

--- a/crates/primitives-traits/Cargo.toml
+++ b/crates/primitives-traits/Cargo.toml
@@ -23,8 +23,11 @@ alloy-primitives.workspace = true
 alloy-rlp.workspace = true
 alloy-trie.workspace = true
 
-# revm-primitives scroll re-export
+# revm-primitives
 revm-primitives = { workspace = true, default-features = false }
+
+# scroll
+scroll-alloy-consensus = { workspace = true, optional = true }
 
 # op
 op-alloy-consensus = { workspace = true, optional = true }
@@ -115,14 +118,16 @@ arbitrary = [
 	"secp256k1?/global-context",
 	"secp256k1?/rand",
 	"op-alloy-consensus?/arbitrary",
-	"alloy-trie/arbitrary"
+	"alloy-trie/arbitrary",
+	"scroll-alloy-consensus?/arbitrary"
 ]
 serde-bincode-compat = [
 	"serde",
 	"serde_with",
 	"alloy-consensus/serde-bincode-compat",
 	"alloy-eips/serde-bincode-compat",
-	"op-alloy-consensus?/serde-bincode-compat"
+	"op-alloy-consensus?/serde-bincode-compat",
+	"scroll-alloy-consensus?/serde-bincode-compat"
 ]
 serde = [
 	"dep:serde",
@@ -136,17 +141,23 @@ serde = [
 	"op-alloy-consensus?/serde",
 	"k256/serde",
 	"secp256k1?/serde",
-	"alloy-trie/serde"
+	"alloy-trie/serde",
+	"scroll-alloy-consensus?/serde"
 ]
 reth-codec = [
 	"dep:reth-codecs",
 	"dep:modular-bitfield",
 	"dep:byteorder",
+	"scroll-alloy-consensus?/reth-codec"
 ]
 op = [
 	"dep:op-alloy-consensus",
 ]
-scroll = ["revm-primitives/scroll"]
+scr = ["scroll-alloy-consensus"]
+scroll = [
+	"revm-primitives/scroll",
+	"scroll-alloy-consensus"
+]
 rayon = [
 	"dep:rayon",
 ]

--- a/crates/primitives-traits/Cargo.toml
+++ b/crates/primitives-traits/Cargo.toml
@@ -153,7 +153,7 @@ reth-codec = [
 op = [
 	"dep:op-alloy-consensus",
 ]
-scr = ["scroll-alloy-consensus"]
+scroll-in-memory-size = ["scroll-alloy-consensus"]
 scroll = ["revm-primitives/scroll"]
 rayon = [
 	"dep:rayon",

--- a/crates/primitives-traits/Cargo.toml
+++ b/crates/primitives-traits/Cargo.toml
@@ -154,10 +154,7 @@ op = [
 	"dep:op-alloy-consensus",
 ]
 scr = ["scroll-alloy-consensus"]
-scroll = [
-	"revm-primitives/scroll",
-	"scroll-alloy-consensus"
-]
+scroll = ["revm-primitives/scroll"]
 rayon = [
 	"dep:rayon",
 ]

--- a/crates/primitives-traits/src/size.rs
+++ b/crates/primitives-traits/src/size.rs
@@ -127,6 +127,18 @@ impl InMemorySize for op_alloy_consensus::OpTypedTransaction {
     }
 }
 
+#[cfg(feature = "scr")]
+impl InMemorySize for scroll_alloy_consensus::ScrollTypedTransaction {
+    fn size(&self) -> usize {
+        match self {
+            Self::Legacy(tx) => tx.size(),
+            Self::Eip2930(tx) => tx.size(),
+            Self::Eip1559(tx) => tx.size(),
+            Self::L1Message(tx) => tx.size(),
+        }
+    }
+}
+
 #[cfg(feature = "op")]
 impl InMemorySize for op_alloy_consensus::OpPooledTransaction {
     fn size(&self) -> usize {

--- a/crates/primitives-traits/src/size.rs
+++ b/crates/primitives-traits/src/size.rs
@@ -127,7 +127,7 @@ impl InMemorySize for op_alloy_consensus::OpTypedTransaction {
     }
 }
 
-#[cfg(feature = "scr")]
+#[cfg(feature = "scroll-in-memory-size")]
 impl InMemorySize for scroll_alloy_consensus::ScrollTypedTransaction {
     fn size(&self) -> usize {
         match self {

--- a/crates/scroll/alloy/consensus/src/lib.rs
+++ b/crates/scroll/alloy/consensus/src/lib.rs
@@ -16,7 +16,7 @@ pub use transaction::{
 };
 
 mod receipt;
-pub use receipt::ScrollReceiptEnvelope;
+pub use receipt::{ScrollReceiptEnvelope, ScrollReceiptWithBloom, ScrollTransactionReceipt};
 
 #[cfg(feature = "serde")]
 pub use transaction::serde_l1_message_tx_rpc;

--- a/crates/scroll/alloy/consensus/src/receipt/mod.rs
+++ b/crates/scroll/alloy/consensus/src/receipt/mod.rs
@@ -1,3 +1,6 @@
 mod envelope;
-
 pub use envelope::ScrollReceiptEnvelope;
+
+#[allow(clippy::module_inception)]
+mod receipt;
+pub use receipt::{ScrollReceiptWithBloom, ScrollTransactionReceipt};

--- a/crates/scroll/alloy/consensus/src/receipt/receipt.rs
+++ b/crates/scroll/alloy/consensus/src/receipt/receipt.rs
@@ -251,8 +251,6 @@ mod tests {
         receipt.encode(&mut data);
         let decoded = ScrollReceiptWithBloom::decode(&mut &data[..]).unwrap();
 
-        // receipt.clone().to_compact(&mut data);
-        // let (decoded, _) = Receipt::from_compact(&data[..], data.len());
         assert_eq!(decoded, receipt);
     }
 }

--- a/crates/scroll/alloy/consensus/src/receipt/receipt.rs
+++ b/crates/scroll/alloy/consensus/src/receipt/receipt.rs
@@ -1,0 +1,258 @@
+//! Transaction receipt types for Scroll.
+
+use alloy_consensus::{
+    Eip658Value, Receipt, ReceiptWithBloom, RlpDecodableReceipt, RlpEncodableReceipt, TxReceipt,
+};
+use alloy_primitives::{Bloom, Log, U256};
+use alloy_rlp::{Buf, BufMut, Decodable, Encodable, Header};
+
+/// Receipt containing result of transaction execution.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct ScrollTransactionReceipt<T = Log> {
+    /// The inner receipt type.
+    #[cfg_attr(feature = "serde", serde(flatten))]
+    pub inner: Receipt<T>,
+    /// L1 fee for Scroll transactions.
+    pub l1_fee: U256,
+}
+
+impl<T> ScrollTransactionReceipt<T> {
+    /// Returns a new [`ScrollTransactionReceipt`] from the inner receipt and the l1 fee.
+    pub const fn new(inner: Receipt<T>, l1_fee: U256) -> Self {
+        Self { inner, l1_fee }
+    }
+}
+
+impl ScrollTransactionReceipt {
+    /// Calculates [`Log`]'s bloom filter. This is slow operation and [`ScrollReceiptWithBloom`]
+    /// can be used to cache this value.
+    pub fn bloom_slow(&self) -> Bloom {
+        self.inner.logs.iter().collect()
+    }
+
+    /// Calculates the bloom filter for the receipt and returns the [`ScrollReceiptWithBloom`]
+    /// container type.
+    pub fn with_bloom(self) -> ScrollReceiptWithBloom {
+        self.into()
+    }
+}
+
+impl<T: Encodable> ScrollTransactionReceipt<T> {
+    /// Returns length of RLP-encoded receipt fields with the given [`Bloom`] without an RLP header.
+    /// Does not include the L1 fee field which is not part of the consensus encoding of a receipt.
+    /// <https://github.com/scroll-tech/go-ethereum/blob/9fff27e4f34fb5097100ed76ee725ce056267f4b/core/types/receipt.go#L96-L102>
+    pub fn rlp_encoded_fields_length_with_bloom(&self, bloom: &Bloom) -> usize {
+        self.inner.rlp_encoded_fields_length_with_bloom(bloom)
+    }
+
+    /// RLP-encodes receipt fields with the given [`Bloom`] without an RLP header.
+    /// Does not include the L1 fee field which is not part of the consensus encoding of a receipt.
+    /// <https://github.com/scroll-tech/go-ethereum/blob/9fff27e4f34fb5097100ed76ee725ce056267f4b/core/types/receipt.go#L96-L102>
+    pub fn rlp_encode_fields_with_bloom(&self, bloom: &Bloom, out: &mut dyn BufMut) {
+        self.inner.rlp_encode_fields_with_bloom(bloom, out);
+    }
+
+    /// Returns RLP header for this receipt encoding with the given [`Bloom`].
+    /// Does not include the L1 fee field which is not part of the consensus encoding of a receipt.
+    /// <https://github.com/scroll-tech/go-ethereum/blob/9fff27e4f34fb5097100ed76ee725ce056267f4b/core/types/receipt.go#L96-L102>
+    pub fn rlp_header_with_bloom(&self, bloom: &Bloom) -> Header {
+        Header { list: true, payload_length: self.rlp_encoded_fields_length_with_bloom(bloom) }
+    }
+}
+
+impl<T: Decodable> ScrollTransactionReceipt<T> {
+    /// RLP-decodes receipt's field with a [`Bloom`].
+    ///
+    /// Does not expect an RLP header.
+    pub fn rlp_decode_fields_with_bloom(
+        buf: &mut &[u8],
+    ) -> alloy_rlp::Result<ReceiptWithBloom<Self>> {
+        let ReceiptWithBloom { receipt: inner, logs_bloom } =
+            Receipt::rlp_decode_fields_with_bloom(buf)?;
+
+        Ok(ReceiptWithBloom { logs_bloom, receipt: Self { inner, l1_fee: Default::default() } })
+    }
+}
+
+impl<T> AsRef<Receipt<T>> for ScrollTransactionReceipt<T> {
+    fn as_ref(&self) -> &Receipt<T> {
+        &self.inner
+    }
+}
+
+impl<T> TxReceipt for ScrollTransactionReceipt<T>
+where
+    T: AsRef<Log> + Clone + core::fmt::Debug + PartialEq + Eq + Send + Sync,
+{
+    type Log = T;
+
+    fn status_or_post_state(&self) -> Eip658Value {
+        self.inner.status_or_post_state()
+    }
+
+    fn status(&self) -> bool {
+        self.inner.status()
+    }
+
+    fn bloom(&self) -> Bloom {
+        self.inner.bloom_slow()
+    }
+
+    fn cumulative_gas_used(&self) -> u64 {
+        self.inner.cumulative_gas_used()
+    }
+
+    fn logs(&self) -> &[Self::Log] {
+        self.inner.logs()
+    }
+}
+
+impl<T: Encodable> RlpEncodableReceipt for ScrollTransactionReceipt<T> {
+    fn rlp_encoded_length_with_bloom(&self, bloom: &Bloom) -> usize {
+        self.rlp_header_with_bloom(bloom).length_with_payload()
+    }
+
+    fn rlp_encode_with_bloom(&self, bloom: &Bloom, out: &mut dyn BufMut) {
+        self.rlp_header_with_bloom(bloom).encode(out);
+        self.rlp_encode_fields_with_bloom(bloom, out);
+    }
+}
+
+impl<T: Decodable> RlpDecodableReceipt for ScrollTransactionReceipt<T> {
+    fn rlp_decode_with_bloom(buf: &mut &[u8]) -> alloy_rlp::Result<ReceiptWithBloom<Self>> {
+        let header = Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+
+        if buf.len() < header.payload_length {
+            return Err(alloy_rlp::Error::InputTooShort);
+        }
+
+        // Note: we pass a separate buffer to `rlp_decode_fields_with_bloom` to allow it decode
+        // optional fields based on the remaining length.
+        let mut fields_buf = &buf[..header.payload_length];
+        let this = Self::rlp_decode_fields_with_bloom(&mut fields_buf)?;
+
+        if !fields_buf.is_empty() {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+
+        buf.advance(header.payload_length);
+
+        Ok(this)
+    }
+}
+
+/// [`ScrollTransactionReceipt`] with calculated bloom filter, modified for Scroll.
+///
+/// This convenience type allows us to lazily calculate the bloom filter for a
+/// receipt, similar to [`Sealed`].
+///
+/// [`Sealed`]: alloy_consensus::Sealed
+pub type ScrollReceiptWithBloom<T = Log> = ReceiptWithBloom<ScrollTransactionReceipt<T>>;
+
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a, T> arbitrary::Arbitrary<'a> for ScrollTransactionReceipt<T>
+where
+    T: arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        #[cfg(not(feature = "std"))]
+        use alloc::vec::Vec;
+        Ok(Self {
+            inner: Receipt {
+                status: Eip658Value::arbitrary(u)?,
+                cumulative_gas_used: u64::arbitrary(u)?,
+                logs: Vec::<T>::arbitrary(u)?,
+            },
+            l1_fee: U256::arbitrary(u)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::Receipt;
+    use alloy_primitives::{address, b256, bytes, hex, Bytes, Log, LogData};
+    use alloy_rlp::{Decodable, Encodable};
+
+    #[cfg(not(feature = "std"))]
+    use alloc::{vec, vec::Vec};
+
+    // Test vector from: https://eips.ethereum.org/EIPS/eip-2481
+    #[test]
+    fn decode_legacy_receipt() {
+        let data = hex!("f901668001b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f85ff85d940000000000000000000000000000000000000011f842a0000000000000000000000000000000000000000000000000000000000000deada0000000000000000000000000000000000000000000000000000000000000beef830100ff");
+
+        // EIP658Receipt
+        let expected =
+            ScrollReceiptWithBloom {
+                receipt: ScrollTransactionReceipt {
+                    inner: Receipt {
+                        status: false.into(),
+                        cumulative_gas_used: 0x1,
+                        logs: vec![Log {
+                            address: address!("0000000000000000000000000000000000000011"),
+                            data: LogData::new_unchecked(
+                                vec![
+                                    b256!("000000000000000000000000000000000000000000000000000000000000dead"),
+                                    b256!("000000000000000000000000000000000000000000000000000000000000beef"),
+                                ],
+                                bytes!("0100ff"),
+                            ),
+                        }],
+                    },
+                    l1_fee: U256::ZERO
+                },
+                logs_bloom: [0; 256].into(),
+            };
+
+        let receipt = ScrollReceiptWithBloom::decode(&mut &data[..]).unwrap();
+        assert_eq!(receipt, expected);
+    }
+
+    #[test]
+    fn gigantic_receipt() {
+        let receipt = ScrollTransactionReceipt {
+            inner: Receipt {
+                cumulative_gas_used: 16747627,
+                status: true.into(),
+                logs: vec![
+                    Log {
+                        address: address!("4bf56695415f725e43c3e04354b604bcfb6dfb6e"),
+                        data: LogData::new_unchecked(
+                            vec![b256!(
+                                "c69dc3d7ebff79e41f525be431d5cd3cc08f80eaf0f7819054a726eeb7086eb9"
+                            )],
+                            Bytes::from(vec![1; 0xffffff]),
+                        ),
+                    },
+                    Log {
+                        address: address!("faca325c86bf9c2d5b413cd7b90b209be92229c2"),
+                        data: LogData::new_unchecked(
+                            vec![b256!(
+                                "8cca58667b1e9ffa004720ac99a3d61a138181963b294d270d91c53d36402ae2"
+                            )],
+                            Bytes::from(vec![1; 0xffffff]),
+                        ),
+                    },
+                ],
+            },
+            l1_fee: U256::ZERO,
+        }
+        .with_bloom();
+
+        let mut data = vec![];
+
+        receipt.encode(&mut data);
+        let decoded = ScrollReceiptWithBloom::decode(&mut &data[..]).unwrap();
+
+        // receipt.clone().to_compact(&mut data);
+        // let (decoded, _) = Receipt::from_compact(&data[..], data.len());
+        assert_eq!(decoded, receipt);
+    }
+}

--- a/crates/scroll/alloy/consensus/src/transaction/tx_type.rs
+++ b/crates/scroll/alloy/consensus/src/transaction/tx_type.rs
@@ -1,9 +1,18 @@
 //! Contains the transaction type identifier for Scroll.
 
+use alloy_consensus::Typed2718;
 use alloy_eips::eip2718::Eip2718Error;
 use alloy_primitives::{U64, U8};
 use alloy_rlp::{BufMut, Decodable, Encodable};
 use derive_more::Display;
+use reth_codecs::{
+    __private::bytes,
+    txtype::{
+        COMPACT_EXTENDED_IDENTIFIER_FLAG, COMPACT_IDENTIFIER_EIP1559, COMPACT_IDENTIFIER_EIP2930,
+        COMPACT_IDENTIFIER_LEGACY,
+    },
+    Compact,
+};
 
 /// Identifier for an Scroll L1 message transaction
 pub const L1_MESSAGE_TX_TYPE_ID: u8 = 126; // 0x7E
@@ -110,6 +119,52 @@ impl Decodable for ScrollTxType {
         let ty = u8::decode(buf)?;
 
         Self::try_from(ty).map_err(|_| alloy_rlp::Error::Custom("invalid transaction type"))
+    }
+}
+
+impl Compact for ScrollTxType {
+    fn to_compact<B>(&self, buf: &mut B) -> usize
+    where
+        B: BufMut + AsMut<[u8]>,
+    {
+        match self {
+            Self::Legacy => COMPACT_IDENTIFIER_LEGACY,
+            Self::Eip2930 => COMPACT_IDENTIFIER_EIP2930,
+            Self::Eip1559 => COMPACT_IDENTIFIER_EIP1559,
+            Self::L1Message => {
+                buf.put_u8(L1_MESSAGE_TX_TYPE_ID);
+                COMPACT_EXTENDED_IDENTIFIER_FLAG
+            }
+        }
+    }
+
+    // For backwards compatibility purposes only 2 bits of the type are encoded in the identifier
+    // parameter. In the case of a [`COMPACT_EXTENDED_IDENTIFIER_FLAG`], the full transaction type
+    // is read from the buffer as a single byte.
+    fn from_compact(mut buf: &[u8], identifier: usize) -> (Self, &[u8]) {
+        use bytes::Buf;
+        (
+            match identifier {
+                COMPACT_IDENTIFIER_LEGACY => Self::Legacy,
+                COMPACT_IDENTIFIER_EIP2930 => Self::Eip2930,
+                COMPACT_IDENTIFIER_EIP1559 => Self::Eip1559,
+                COMPACT_EXTENDED_IDENTIFIER_FLAG => {
+                    let extended_identifier = buf.get_u8();
+                    match extended_identifier {
+                        L1_MESSAGE_TX_TYPE_ID => Self::L1Message,
+                        _ => panic!("Unsupported TxType identifier: {extended_identifier}"),
+                    }
+                }
+                _ => panic!("Unknown identifier for TxType: {identifier}"),
+            },
+            buf,
+        )
+    }
+}
+
+impl Typed2718 for ScrollTxType {
+    fn ty(&self) -> u8 {
+        (*self).into()
     }
 }
 

--- a/crates/scroll/alloy/consensus/src/transaction/typed.rs
+++ b/crates/scroll/alloy/consensus/src/transaction/typed.rs
@@ -2,6 +2,8 @@ use crate::{ScrollTxEnvelope, ScrollTxType, TxL1Message};
 use alloy_consensus::{Transaction, TxEip1559, TxEip2930, TxLegacy, Typed2718};
 use alloy_eips::eip2930::AccessList;
 use alloy_primitives::{Address, Bytes, TxKind};
+use reth_codecs::{Compact, __private::bytes};
+use reth_codecs_derive::generate_tests;
 
 /// The `TypedTransaction` enum represents all Ethereum transaction request types, modified for
 /// Scroll
@@ -285,6 +287,50 @@ impl Transaction for ScrollTypedTransaction {
         }
     }
 }
+
+impl Compact for ScrollTypedTransaction {
+    fn to_compact<B>(&self, out: &mut B) -> usize
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
+    {
+        let identifier = self.tx_type().to_compact(out);
+        match self {
+            Self::Legacy(tx) => tx.to_compact(out),
+            Self::Eip2930(tx) => tx.to_compact(out),
+            Self::Eip1559(tx) => tx.to_compact(out),
+            Self::L1Message(tx) => tx.to_compact(out),
+        };
+        identifier
+    }
+
+    fn from_compact(buf: &[u8], identifier: usize) -> (Self, &[u8]) {
+        let (tx_type, buf) = ScrollTxType::from_compact(buf, identifier);
+        match tx_type {
+            ScrollTxType::Legacy => {
+                let (tx, buf) = Compact::from_compact(buf, buf.len());
+                (Self::Legacy(tx), buf)
+            }
+            ScrollTxType::Eip2930 => {
+                let (tx, buf) = Compact::from_compact(buf, buf.len());
+                (Self::Eip2930(tx), buf)
+            }
+            ScrollTxType::Eip1559 => {
+                let (tx, buf) = Compact::from_compact(buf, buf.len());
+                (Self::Eip1559(tx), buf)
+            }
+            ScrollTxType::L1Message => {
+                let (tx, buf) = Compact::from_compact(buf, buf.len());
+                (Self::L1Message(tx), buf)
+            }
+        }
+    }
+}
+
+generate_tests!(
+    #[compact]
+    ScrollTypedTransaction,
+    ScrollTypedTransactionTests
+);
 
 #[cfg(feature = "serde")]
 mod serde_from {

--- a/crates/scroll/node/Cargo.toml
+++ b/crates/scroll/node/Cargo.toml
@@ -39,6 +39,7 @@ alloy-rpc-types-engine.workspace = true
 reth-scroll-chainspec.workspace = true
 reth-scroll-engine.workspace = true
 reth-scroll-evm.workspace = true
+reth-scroll-primitives = { workspace = true, features = ["serde", "serde-bincode-compat"] }
 reth-scroll-rpc.workspace = true
 
 # alloy
@@ -48,6 +49,7 @@ alloy-primitives.workspace = true
 eyre.workspace = true
 
 [features]
+default = ["reth-codec"]
 optimism = [
 	"reth-db/optimism",
 	"reth-primitives/optimism",
@@ -65,5 +67,12 @@ scroll = [
 	"reth-scroll-evm/scroll",
 	"reth-scroll-engine/scroll",
 	"reth-scroll-rpc/scroll",
+	"reth-scroll-primitives/scroll",
+	"reth-primitives-traits/scroll"
+]
+reth-codec = [
+	"reth-primitives/reth-codec",
+	"reth-primitives-traits/reth-codec",
+	"reth-scroll-primitives/reth-codec"
 ]
 skip-state-root-validation = []

--- a/crates/scroll/primitives/Cargo.toml
+++ b/crates/scroll/primitives/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 # reth
 reth-codecs = { workspace = true, optional = true }
-reth-primitives-traits = { workspace = true, features = ["scr"] }
+reth-primitives-traits = { workspace = true, features = ["scroll-in-memory-size"] }
 reth-zstd-compressors = { workspace = true, optional = true }
 
 # revm

--- a/crates/scroll/primitives/Cargo.toml
+++ b/crates/scroll/primitives/Cargo.toml
@@ -1,0 +1,122 @@
+[package]
+name = "reth-scroll-primitives"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# reth
+reth-codecs = { workspace = true, optional = true }
+reth-primitives-traits = { workspace = true, features = ["scr"] }
+reth-zstd-compressors = { workspace = true, optional = true }
+
+# revm
+revm-primitives = { workspace = true, optional = true }
+
+# alloy
+alloy-consensus.workspace = true
+alloy-eips.workspace = true
+alloy-primitives.workspace = true
+alloy-rlp.workspace = true
+
+# scroll
+scroll-alloy-consensus.workspace = true
+
+# codec
+bytes = { workspace = true, optional = true }
+modular-bitfield = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+
+# misc
+derive_more.workspace = true
+once_cell.workspace = true
+rand = { workspace = true, optional = true }
+
+# test
+arbitrary = { workspace = true, features = ["derive"], optional = true }
+proptest = { workspace = true, optional = true }
+secp256k1 = { workspace = true, optional = true }
+
+[dev-dependencies]
+proptest-arbitrary-interop.workspace = true
+reth-codecs = { workspace = true, features = ["test-utils"] }
+rstest.workspace = true
+proptest.workspace = true
+secp256k1 = { workspace = true, features = ["rand"] }
+rand.workspace = true
+
+[features]
+default = ["std"]
+std = [
+    "serde?/std",
+    "scroll-alloy-consensus/std",
+    "alloy-consensus/std",
+    "alloy-eips/std",
+    "alloy-primitives/std",
+    "alloy-rlp/std",
+    "bytes?/std",
+    "reth-primitives-traits/std",
+    "reth-zstd-compressors?/std",
+    "reth-codecs?/std",
+    "derive_more/std",
+    "once_cell/std",
+    "proptest?/std",
+    "serde?/std",
+    "rand?/std",
+    "secp256k1?/std",
+    "revm-primitives?/std"
+]
+reth-codec = [
+    "dep:reth-codecs",
+    "std",
+    "dep:proptest",
+    "dep:arbitrary",
+    "reth-primitives-traits/reth-codec",
+    "scroll-alloy-consensus/reth-codec",
+    "dep:bytes",
+    "dep:modular-bitfield",
+    "dep:reth-zstd-compressors"
+]
+serde = [
+    "dep:serde",
+    "scroll-alloy-consensus/serde",
+    "secp256k1?/serde",
+    "alloy-consensus/serde",
+    "alloy-eips/serde",
+    "alloy-primitives/serde",
+    "bytes?/serde",
+    "rand?/serde",
+    "reth-codecs?/serde",
+    "reth-primitives-traits/serde" ,
+    "revm-primitives?/serde",
+]
+serde-bincode-compat = [
+    "alloy-consensus/serde-bincode-compat",
+    "alloy-eips/serde-bincode-compat",
+    "reth-primitives-traits/serde-bincode-compat",
+    "scroll-alloy-consensus/serde-bincode-compat"
+]
+arbitrary = [
+    "dep:arbitrary",
+    "dep:secp256k1",
+    "secp256k1?/rand",
+    "rand",
+    "alloy-consensus/arbitrary",
+    "alloy-eips/arbitrary",
+    "alloy-primitives/arbitrary",
+    "reth-codecs?/arbitrary",
+    "reth-primitives-traits/arbitrary",
+    "revm-primitives?/arbitrary",
+    "scroll-alloy-consensus/arbitrary"
+]
+scroll = [
+    "dep:revm-primitives",
+    "revm-primitives/scroll",
+    "reth-primitives-traits/scroll"
+]

--- a/crates/scroll/primitives/src/lib.rs
+++ b/crates/scroll/primitives/src/lib.rs
@@ -1,0 +1,41 @@
+//! Commonly used types in Scroll.
+
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/paradigmxyz/reth/main/assets/reth-docs.png",
+    html_favicon_url = "https://avatars0.githubusercontent.com/u/97369466?s=256",
+    issue_tracker_base_url = "https://github.com/scroll-tech/reth/issues/"
+)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use once_cell as _;
+
+extern crate alloc;
+
+pub mod transaction;
+pub use transaction::{signed::ScrollTransactionSigned, tx_type::ScrollTxType};
+
+use reth_primitives_traits::Block;
+
+mod receipt;
+pub use receipt::ScrollReceipt;
+
+/// Scroll-specific block type.
+pub type ScrollBlock = alloy_consensus::Block<ScrollTransactionSigned>;
+
+/// Scroll-specific block body type.
+pub type ScrollBlockBody = <ScrollBlock as Block>::Body;
+
+/// Primitive types for Scroll Node.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ScrollPrimitives;
+
+#[cfg(feature = "scroll")]
+impl reth_primitives_traits::NodePrimitives for ScrollPrimitives {
+    type Block = ScrollBlock;
+    type BlockHeader = alloy_consensus::Header;
+    type BlockBody = ScrollBlockBody;
+    type SignedTx = ScrollTransactionSigned;
+    type Receipt = ScrollReceipt;
+}

--- a/crates/scroll/primitives/src/receipt.rs
+++ b/crates/scroll/primitives/src/receipt.rs
@@ -24,7 +24,7 @@ pub enum ScrollReceipt {
 }
 
 impl ScrollReceipt {
-    /// Returns [`OpTxType`] of the receipt.
+    /// Returns [`ScrollTxType`] of the receipt.
     pub const fn tx_type(&self) -> ScrollTxType {
         match self {
             Self::Legacy(_) => ScrollTxType::Legacy,

--- a/crates/scroll/primitives/src/receipt.rs
+++ b/crates/scroll/primitives/src/receipt.rs
@@ -1,0 +1,281 @@
+use alloy_consensus::{
+    Eip2718EncodableReceipt, Eip658Value, Receipt, ReceiptWithBloom, RlpDecodableReceipt,
+    RlpEncodableReceipt, TxReceipt, Typed2718,
+};
+use alloy_primitives::{Bloom, Log, U256};
+use alloy_rlp::{BufMut, Decodable, Header};
+use reth_primitives_traits::InMemorySize;
+use scroll_alloy_consensus::{ScrollTransactionReceipt, ScrollTxReceipt, ScrollTxType};
+
+/// Typed ethereum transaction receipt.
+/// Receipt containing result of transaction execution.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub enum ScrollReceipt {
+    /// Legacy receipt
+    Legacy(ScrollTransactionReceipt),
+    /// EIP-2930 receipt
+    Eip2930(ScrollTransactionReceipt),
+    /// EIP-1559 receipt
+    Eip1559(ScrollTransactionReceipt),
+    /// L1 message receipt
+    L1Message(Receipt),
+}
+
+impl ScrollReceipt {
+    /// Returns [`OpTxType`] of the receipt.
+    pub const fn tx_type(&self) -> ScrollTxType {
+        match self {
+            Self::Legacy(_) => ScrollTxType::Legacy,
+            Self::Eip2930(_) => ScrollTxType::Eip2930,
+            Self::Eip1559(_) => ScrollTxType::Eip1559,
+            Self::L1Message(_) => ScrollTxType::L1Message,
+        }
+    }
+
+    /// Returns inner [`Receipt`],
+    pub const fn as_receipt(&self) -> &Receipt {
+        match self {
+            Self::Legacy(receipt) | Self::Eip2930(receipt) | Self::Eip1559(receipt) => {
+                &receipt.inner
+            }
+            Self::L1Message(receipt) => receipt,
+        }
+    }
+
+    /// Returns length of RLP-encoded receipt fields with the given [`Bloom`] without an RLP header.
+    pub fn rlp_encoded_fields_length(&self, bloom: &Bloom) -> usize {
+        match self {
+            Self::Legacy(receipt) | Self::Eip2930(receipt) | Self::Eip1559(receipt) => {
+                receipt.rlp_encoded_fields_length_with_bloom(bloom)
+            }
+            Self::L1Message(receipt) => receipt.rlp_encoded_fields_length_with_bloom(bloom),
+        }
+    }
+
+    /// RLP-encodes receipt fields with the given [`Bloom`] without an RLP header.
+    pub fn rlp_encode_fields(&self, bloom: &Bloom, out: &mut dyn BufMut) {
+        match self {
+            Self::Legacy(receipt) | Self::Eip2930(receipt) | Self::Eip1559(receipt) => {
+                receipt.rlp_encode_fields_with_bloom(bloom, out)
+            }
+            Self::L1Message(receipt) => receipt.rlp_encode_fields_with_bloom(bloom, out),
+        }
+    }
+
+    /// Returns RLP header for inner encoding.
+    pub fn rlp_header_inner(&self, bloom: &Bloom) -> Header {
+        Header { list: true, payload_length: self.rlp_encoded_fields_length(bloom) }
+    }
+
+    /// RLP-decodes the receipt from the provided buffer. This does not expect a type byte or
+    /// network header.
+    pub fn rlp_decode_inner(
+        buf: &mut &[u8],
+        tx_type: ScrollTxType,
+    ) -> alloy_rlp::Result<ReceiptWithBloom<Self>> {
+        match tx_type {
+            ScrollTxType::Legacy => {
+                let ReceiptWithBloom { receipt, logs_bloom } =
+                    RlpDecodableReceipt::rlp_decode_with_bloom(buf)?;
+                Ok(ReceiptWithBloom { receipt: Self::Legacy(receipt), logs_bloom })
+            }
+            ScrollTxType::Eip2930 => {
+                let ReceiptWithBloom { receipt, logs_bloom } =
+                    RlpDecodableReceipt::rlp_decode_with_bloom(buf)?;
+                Ok(ReceiptWithBloom { receipt: Self::Eip2930(receipt), logs_bloom })
+            }
+            ScrollTxType::Eip1559 => {
+                let ReceiptWithBloom { receipt, logs_bloom } =
+                    RlpDecodableReceipt::rlp_decode_with_bloom(buf)?;
+                Ok(ReceiptWithBloom { receipt: Self::Eip1559(receipt), logs_bloom })
+            }
+            ScrollTxType::L1Message => {
+                let ReceiptWithBloom { receipt, logs_bloom } =
+                    RlpDecodableReceipt::rlp_decode_with_bloom(buf)?;
+                Ok(ReceiptWithBloom { receipt: Self::L1Message(receipt), logs_bloom })
+            }
+        }
+    }
+
+    /// Returns the l1 fee for the transaction receipt.
+    pub fn l1_fee(&self) -> U256 {
+        match self {
+            Self::Legacy(receipt) | Self::Eip2930(receipt) | Self::Eip1559(receipt) => {
+                receipt.l1_fee()
+            }
+            Self::L1Message(_) => U256::ZERO,
+        }
+    }
+}
+
+impl Eip2718EncodableReceipt for ScrollReceipt {
+    fn eip2718_encoded_length_with_bloom(&self, bloom: &Bloom) -> usize {
+        !self.tx_type().is_legacy() as usize + self.rlp_header_inner(bloom).length_with_payload()
+    }
+
+    fn eip2718_encode_with_bloom(&self, bloom: &Bloom, out: &mut dyn BufMut) {
+        if !self.tx_type().is_legacy() {
+            out.put_u8(self.tx_type() as u8);
+        }
+        self.rlp_header_inner(bloom).encode(out);
+        self.rlp_encode_fields(bloom, out);
+    }
+}
+
+impl RlpEncodableReceipt for ScrollReceipt {
+    fn rlp_encoded_length_with_bloom(&self, bloom: &Bloom) -> usize {
+        let mut len = self.eip2718_encoded_length_with_bloom(bloom);
+        if !self.tx_type().is_legacy() {
+            len += Header {
+                list: false,
+                payload_length: self.eip2718_encoded_length_with_bloom(bloom),
+            }
+            .length();
+        }
+
+        len
+    }
+
+    fn rlp_encode_with_bloom(&self, bloom: &Bloom, out: &mut dyn BufMut) {
+        if !self.tx_type().is_legacy() {
+            Header { list: false, payload_length: self.eip2718_encoded_length_with_bloom(bloom) }
+                .encode(out);
+        }
+        self.eip2718_encode_with_bloom(bloom, out);
+    }
+}
+
+impl RlpDecodableReceipt for ScrollReceipt {
+    fn rlp_decode_with_bloom(buf: &mut &[u8]) -> alloy_rlp::Result<ReceiptWithBloom<Self>> {
+        let header_buf = &mut &**buf;
+        let header = Header::decode(header_buf)?;
+
+        // Legacy receipt, reuse initial buffer without advancing
+        if header.list {
+            return Self::rlp_decode_inner(buf, ScrollTxType::Legacy)
+        }
+
+        // Otherwise, advance the buffer and try decoding type flag followed by receipt
+        *buf = *header_buf;
+
+        let remaining = buf.len();
+        let tx_type = ScrollTxType::decode(buf)?;
+        let this = Self::rlp_decode_inner(buf, tx_type)?;
+
+        if buf.len() + header.payload_length != remaining {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+
+        Ok(this)
+    }
+}
+
+impl TxReceipt for ScrollReceipt {
+    type Log = Log;
+
+    fn status_or_post_state(&self) -> Eip658Value {
+        self.as_receipt().status_or_post_state()
+    }
+
+    fn status(&self) -> bool {
+        self.as_receipt().status()
+    }
+
+    fn bloom(&self) -> Bloom {
+        self.as_receipt().bloom()
+    }
+
+    fn cumulative_gas_used(&self) -> u64 {
+        self.as_receipt().cumulative_gas_used()
+    }
+
+    fn logs(&self) -> &[Log] {
+        self.as_receipt().logs()
+    }
+}
+
+impl Typed2718 for ScrollReceipt {
+    fn ty(&self) -> u8 {
+        self.tx_type().into()
+    }
+}
+
+impl InMemorySize for ScrollReceipt {
+    fn size(&self) -> usize {
+        self.as_receipt().size()
+    }
+}
+
+impl reth_primitives_traits::Receipt for ScrollReceipt {}
+
+#[cfg(feature = "reth-codec")]
+mod compact {
+    use super::*;
+    use alloc::borrow::Cow;
+    use alloy_primitives::U256;
+    use reth_codecs::Compact;
+
+    #[derive(reth_codecs::CompactZstd)]
+    #[reth_zstd(
+        compressor = reth_zstd_compressors::RECEIPT_COMPRESSOR,
+        decompressor = reth_zstd_compressors::RECEIPT_DECOMPRESSOR
+    )]
+    struct CompactScrollReceipt<'a> {
+        tx_type: ScrollTxType,
+        success: bool,
+        cumulative_gas_used: u64,
+        logs: Cow<'a, Vec<Log>>,
+        l1_fee: Option<U256>,
+    }
+
+    impl<'a> From<&'a ScrollReceipt> for CompactScrollReceipt<'a> {
+        fn from(receipt: &'a ScrollReceipt) -> Self {
+            Self {
+                tx_type: receipt.tx_type(),
+                success: receipt.status(),
+                cumulative_gas_used: receipt.cumulative_gas_used(),
+                logs: Cow::Borrowed(&receipt.as_receipt().logs),
+                l1_fee: (receipt.l1_fee() != U256::ZERO).then_some(receipt.l1_fee()),
+            }
+        }
+    }
+
+    impl From<CompactScrollReceipt<'_>> for ScrollReceipt {
+        fn from(receipt: CompactScrollReceipt<'_>) -> Self {
+            let CompactScrollReceipt { tx_type, success, cumulative_gas_used, logs, l1_fee } =
+                receipt;
+
+            let inner =
+                Receipt { status: success.into(), cumulative_gas_used, logs: logs.into_owned() };
+
+            match tx_type {
+                ScrollTxType::Legacy => {
+                    Self::Legacy(ScrollTransactionReceipt::new(inner, l1_fee.unwrap_or_default()))
+                }
+                ScrollTxType::Eip2930 => {
+                    Self::Eip2930(ScrollTransactionReceipt::new(inner, l1_fee.unwrap_or_default()))
+                }
+                ScrollTxType::Eip1559 => {
+                    Self::Eip1559(ScrollTransactionReceipt::new(inner, l1_fee.unwrap_or_default()))
+                }
+                ScrollTxType::L1Message => Self::L1Message(inner),
+            }
+        }
+    }
+
+    impl Compact for ScrollReceipt {
+        fn to_compact<B>(&self, buf: &mut B) -> usize
+        where
+            B: bytes::BufMut + AsMut<[u8]>,
+        {
+            CompactScrollReceipt::from(self).to_compact(buf)
+        }
+
+        fn from_compact(buf: &[u8], len: usize) -> (Self, &[u8]) {
+            let (receipt, buf) = CompactScrollReceipt::from_compact(buf, len);
+            (receipt.into(), buf)
+        }
+    }
+}

--- a/crates/scroll/primitives/src/receipt.rs
+++ b/crates/scroll/primitives/src/receipt.rs
@@ -5,7 +5,7 @@ use alloy_consensus::{
 use alloy_primitives::{Bloom, Log, U256};
 use alloy_rlp::{BufMut, Decodable, Header};
 use reth_primitives_traits::InMemorySize;
-use scroll_alloy_consensus::{ScrollTransactionReceipt, ScrollTxReceipt, ScrollTxType};
+use scroll_alloy_consensus::{ScrollTransactionReceipt, ScrollTxType};
 
 /// Typed ethereum transaction receipt.
 /// Receipt containing result of transaction execution.
@@ -100,10 +100,10 @@ impl ScrollReceipt {
     }
 
     /// Returns the l1 fee for the transaction receipt.
-    pub fn l1_fee(&self) -> U256 {
+    pub const fn l1_fee(&self) -> U256 {
         match self {
             Self::Legacy(receipt) | Self::Eip2930(receipt) | Self::Eip1559(receipt) => {
-                receipt.l1_fee()
+                receipt.l1_fee
             }
             Self::L1Message(_) => U256::ZERO,
         }

--- a/crates/scroll/primitives/src/transaction/mod.rs
+++ b/crates/scroll/primitives/src/transaction/mod.rs
@@ -1,0 +1,4 @@
+//! Scroll primitives transaction types.
+
+pub mod signed;
+pub mod tx_type;

--- a/crates/scroll/primitives/src/transaction/signed.rs
+++ b/crates/scroll/primitives/src/transaction/signed.rs
@@ -63,7 +63,7 @@ impl ScrollTransactionSigned {
 
     /// Creates a new signed transaction from the given transaction and signature without the hash.
     ///
-    /// Note: this only calculates the hash on the first [`OpTransactionSigned::hash`] call.
+    /// Note: this only calculates the hash on the first [`ScrollTransactionSigned::hash`] call.
     pub fn new_unhashed(transaction: ScrollTypedTransaction, signature: Signature) -> Self {
         Self { hash: Default::default(), signature, transaction }
     }

--- a/crates/scroll/primitives/src/transaction/signed.rs
+++ b/crates/scroll/primitives/src/transaction/signed.rs
@@ -1,0 +1,596 @@
+//! A signed Scroll transaction.
+
+use crate::ScrollTxType;
+use alloc::vec::Vec;
+use alloy_consensus::{
+    transaction::RlpEcdsaTx, SignableTransaction, Signed, Transaction, TxEip1559, TxEip2930,
+    TxLegacy, Typed2718,
+};
+use alloy_eips::{
+    eip2718::{Decodable2718, Eip2718Error, Eip2718Result, Encodable2718},
+    eip2930::AccessList,
+    eip7702::SignedAuthorization,
+};
+use alloy_primitives::{
+    keccak256, Address, Bytes, PrimitiveSignature as Signature, TxHash, TxKind, Uint, B256,
+};
+use alloy_rlp::Header;
+#[cfg(feature = "reth-codec")]
+use arbitrary as _;
+use core::{
+    hash::{Hash, Hasher},
+    mem,
+};
+use derive_more::{AsRef, Deref};
+#[cfg(not(feature = "std"))]
+use once_cell::sync::OnceCell as OnceLock;
+#[cfg(any(test, feature = "reth-codec"))]
+use proptest as _;
+use reth_primitives_traits::{
+    crypto::secp256k1::{recover_signer, recover_signer_unchecked},
+    InMemorySize, SignedTransaction,
+};
+use scroll_alloy_consensus::{ScrollTypedTransaction, TxL1Message};
+#[cfg(feature = "std")]
+use std::sync::OnceLock;
+
+/// Signed transaction.
+#[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(rlp))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Eq, AsRef, Deref)]
+pub struct ScrollTransactionSigned {
+    /// Transaction hash
+    #[cfg_attr(feature = "serde", serde(skip))]
+    pub hash: OnceLock<TxHash>,
+    /// The transaction signature values
+    pub signature: Signature,
+    /// Raw transaction info
+    #[deref]
+    #[as_ref]
+    pub transaction: ScrollTypedTransaction,
+}
+
+impl ScrollTransactionSigned {
+    /// Calculates hash of given transaction and signature and returns new instance.
+    pub fn new(transaction: ScrollTypedTransaction, signature: Signature) -> Self {
+        let signed_tx = Self::new_unhashed(transaction, signature);
+        if signed_tx.ty() != ScrollTxType::L1Message {
+            signed_tx.hash.get_or_init(|| signed_tx.recalculate_hash());
+        }
+
+        signed_tx
+    }
+
+    /// Creates a new signed transaction from the given transaction and signature without the hash.
+    ///
+    /// Note: this only calculates the hash on the first [`OpTransactionSigned::hash`] call.
+    pub fn new_unhashed(transaction: ScrollTypedTransaction, signature: Signature) -> Self {
+        Self { hash: Default::default(), signature, transaction }
+    }
+
+    /// Returns whether this transaction is a l1 message.
+    pub const fn is_l1_message(&self) -> bool {
+        matches!(self.transaction, ScrollTypedTransaction::L1Message(_))
+    }
+}
+
+impl SignedTransaction for ScrollTransactionSigned {
+    fn tx_hash(&self) -> &TxHash {
+        self.hash.get_or_init(|| self.recalculate_hash())
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn recover_signer(&self) -> Option<Address> {
+        // Scroll's L1 message does not have a signature. Directly return the `sender` address.
+        if let ScrollTypedTransaction::L1Message(TxL1Message { sender, .. }) = self.transaction {
+            return Some(sender)
+        }
+
+        let Self { transaction, signature, .. } = self;
+        let signature_hash = signature_hash(transaction);
+        recover_signer(signature, signature_hash)
+    }
+
+    fn recover_signer_unchecked(&self) -> Option<Address> {
+        // Scroll's L1 message does not have a signature. Directly return the `sender` address.
+        if let ScrollTypedTransaction::L1Message(TxL1Message { sender, .. }) = &self.transaction {
+            return Some(*sender)
+        }
+
+        let Self { transaction, signature, .. } = self;
+        let signature_hash = signature_hash(transaction);
+        recover_signer_unchecked(signature, signature_hash)
+    }
+
+    fn recover_signer_unchecked_with_buf(&self, buf: &mut Vec<u8>) -> Option<Address> {
+        match &self.transaction {
+            // Scroll's L1 message does not have a signature. Directly return the `sender` address.
+            ScrollTypedTransaction::L1Message(tx) => return Some(tx.sender),
+            ScrollTypedTransaction::Legacy(tx) => tx.encode_for_signing(buf),
+            ScrollTypedTransaction::Eip2930(tx) => tx.encode_for_signing(buf),
+            ScrollTypedTransaction::Eip1559(tx) => tx.encode_for_signing(buf),
+        };
+        recover_signer_unchecked(&self.signature, keccak256(buf))
+    }
+
+    fn recalculate_hash(&self) -> B256 {
+        keccak256(self.encoded_2718())
+    }
+}
+
+#[cfg(feature = "scroll")]
+impl reth_primitives_traits::FillTxEnv for ScrollTransactionSigned {
+    fn fill_tx_env(&self, tx_env: &mut revm_primitives::TxEnv, sender: Address) {
+        let envelope = self.encoded_2718();
+
+        tx_env.caller = sender;
+        match &self.transaction {
+            ScrollTypedTransaction::Legacy(tx) => {
+                tx_env.gas_limit = tx.gas_limit;
+                tx_env.gas_price = alloy_primitives::U256::from(tx.gas_price);
+                tx_env.gas_priority_fee = None;
+                tx_env.transact_to = tx.to;
+                tx_env.value = tx.value;
+                tx_env.data = tx.input.clone();
+                tx_env.chain_id = tx.chain_id;
+                tx_env.nonce = Some(tx.nonce);
+                tx_env.access_list.clear();
+                tx_env.blob_hashes.clear();
+                tx_env.max_fee_per_blob_gas.take();
+                tx_env.authorization_list = None;
+            }
+            ScrollTypedTransaction::Eip2930(tx) => {
+                tx_env.gas_limit = tx.gas_limit;
+                tx_env.gas_price = alloy_primitives::U256::from(tx.gas_price);
+                tx_env.gas_priority_fee = None;
+                tx_env.transact_to = tx.to;
+                tx_env.value = tx.value;
+                tx_env.data = tx.input.clone();
+                tx_env.chain_id = Some(tx.chain_id);
+                tx_env.nonce = Some(tx.nonce);
+                tx_env.access_list.clone_from(&tx.access_list.0);
+                tx_env.blob_hashes.clear();
+                tx_env.max_fee_per_blob_gas.take();
+                tx_env.authorization_list = None;
+            }
+            ScrollTypedTransaction::Eip1559(tx) => {
+                tx_env.gas_limit = tx.gas_limit;
+                tx_env.gas_price = alloy_primitives::U256::from(tx.max_fee_per_gas);
+                tx_env.gas_priority_fee =
+                    Some(alloy_primitives::U256::from(tx.max_priority_fee_per_gas));
+                tx_env.transact_to = tx.to;
+                tx_env.value = tx.value;
+                tx_env.data = tx.input.clone();
+                tx_env.chain_id = Some(tx.chain_id);
+                tx_env.nonce = Some(tx.nonce);
+                tx_env.access_list.clone_from(&tx.access_list.0);
+                tx_env.blob_hashes.clear();
+                tx_env.max_fee_per_blob_gas.take();
+                tx_env.authorization_list = None;
+            }
+            ScrollTypedTransaction::L1Message(tx) => {
+                tx_env.access_list.clear();
+                tx_env.gas_limit = tx.gas_limit;
+                tx_env.gas_price = alloy_primitives::U256::ZERO;
+                tx_env.gas_priority_fee = None;
+                tx_env.transact_to = TxKind::Call(tx.to);
+                tx_env.value = tx.value;
+                tx_env.data = tx.input.clone();
+                tx_env.chain_id = None;
+                tx_env.nonce = None;
+                tx_env.authorization_list = None;
+
+                tx_env.scroll = revm_primitives::ScrollFields {
+                    is_l1_msg: true,
+                    rlp_bytes: Some(envelope.into()),
+                };
+                return
+            }
+        }
+
+        tx_env.scroll =
+            revm_primitives::ScrollFields { is_l1_msg: false, rlp_bytes: Some(envelope.into()) }
+    }
+}
+
+impl InMemorySize for ScrollTransactionSigned {
+    #[inline]
+    fn size(&self) -> usize {
+        mem::size_of::<TxHash>() + self.transaction.size() + mem::size_of::<Signature>()
+    }
+}
+
+impl alloy_rlp::Encodable for ScrollTransactionSigned {
+    fn encode(&self, out: &mut dyn alloy_rlp::bytes::BufMut) {
+        self.network_encode(out);
+    }
+
+    fn length(&self) -> usize {
+        let mut payload_length = self.encode_2718_len();
+        if !Encodable2718::is_legacy(self) {
+            payload_length += Header { list: false, payload_length }.length();
+        }
+
+        payload_length
+    }
+}
+
+impl alloy_rlp::Decodable for ScrollTransactionSigned {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        Self::network_decode(buf).map_err(Into::into)
+    }
+}
+
+impl Encodable2718 for ScrollTransactionSigned {
+    fn type_flag(&self) -> Option<u8> {
+        if Typed2718::is_legacy(self) {
+            None
+        } else {
+            Some(self.ty())
+        }
+    }
+
+    fn encode_2718_len(&self) -> usize {
+        match &self.transaction {
+            ScrollTypedTransaction::Legacy(legacy_tx) => {
+                legacy_tx.eip2718_encoded_length(&self.signature)
+            }
+            ScrollTypedTransaction::Eip2930(access_list_tx) => {
+                access_list_tx.eip2718_encoded_length(&self.signature)
+            }
+            ScrollTypedTransaction::Eip1559(dynamic_fee_tx) => {
+                dynamic_fee_tx.eip2718_encoded_length(&self.signature)
+            }
+            ScrollTypedTransaction::L1Message(l1_message) => l1_message.eip2718_encoded_length(),
+        }
+    }
+
+    fn encode_2718(&self, out: &mut dyn alloy_rlp::BufMut) {
+        let Self { transaction, signature, .. } = self;
+
+        match &transaction {
+            ScrollTypedTransaction::Legacy(legacy_tx) => {
+                // do nothing w/ with_header
+                legacy_tx.eip2718_encode(signature, out)
+            }
+            ScrollTypedTransaction::Eip2930(access_list_tx) => {
+                access_list_tx.eip2718_encode(signature, out)
+            }
+            ScrollTypedTransaction::Eip1559(dynamic_fee_tx) => {
+                dynamic_fee_tx.eip2718_encode(signature, out)
+            }
+            ScrollTypedTransaction::L1Message(l1_message) => l1_message.encode_2718(out),
+        }
+    }
+}
+
+impl Decodable2718 for ScrollTransactionSigned {
+    fn typed_decode(ty: u8, buf: &mut &[u8]) -> Eip2718Result<Self> {
+        match ty.try_into().map_err(|_| Eip2718Error::UnexpectedType(ty))? {
+            ScrollTxType::Legacy => Err(Eip2718Error::UnexpectedType(0)),
+            ScrollTxType::Eip2930 => {
+                let (tx, signature, hash) = TxEip2930::rlp_decode_signed(buf)?.into_parts();
+                let signed_tx = Self::new_unhashed(ScrollTypedTransaction::Eip2930(tx), signature);
+                signed_tx.hash.get_or_init(|| hash);
+                Ok(signed_tx)
+            }
+            ScrollTxType::Eip1559 => {
+                let (tx, signature, hash) = TxEip1559::rlp_decode_signed(buf)?.into_parts();
+                let signed_tx = Self::new_unhashed(ScrollTypedTransaction::Eip1559(tx), signature);
+                signed_tx.hash.get_or_init(|| hash);
+                Ok(signed_tx)
+            }
+            ScrollTxType::L1Message => Ok(Self::new_unhashed(
+                ScrollTypedTransaction::L1Message(TxL1Message::rlp_decode(buf)?),
+                TxL1Message::signature(),
+            )),
+        }
+    }
+
+    fn fallback_decode(buf: &mut &[u8]) -> Eip2718Result<Self> {
+        let (transaction, signature) = TxLegacy::rlp_decode_with_signature(buf)?;
+        let signed_tx = Self::new_unhashed(ScrollTypedTransaction::Legacy(transaction), signature);
+
+        Ok(signed_tx)
+    }
+}
+
+impl Transaction for ScrollTransactionSigned {
+    fn chain_id(&self) -> Option<u64> {
+        self.deref().chain_id()
+    }
+
+    fn nonce(&self) -> u64 {
+        self.deref().nonce()
+    }
+
+    fn gas_limit(&self) -> u64 {
+        self.deref().gas_limit()
+    }
+
+    fn gas_price(&self) -> Option<u128> {
+        self.deref().gas_price()
+    }
+
+    fn max_fee_per_gas(&self) -> u128 {
+        self.deref().max_fee_per_gas()
+    }
+
+    fn max_priority_fee_per_gas(&self) -> Option<u128> {
+        self.deref().max_priority_fee_per_gas()
+    }
+
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        self.deref().max_fee_per_blob_gas()
+    }
+
+    fn priority_fee_or_price(&self) -> u128 {
+        self.deref().priority_fee_or_price()
+    }
+
+    fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
+        self.deref().effective_gas_price(base_fee)
+    }
+
+    fn effective_tip_per_gas(&self, base_fee: u64) -> Option<u128> {
+        self.deref().effective_tip_per_gas(base_fee)
+    }
+
+    fn is_dynamic_fee(&self) -> bool {
+        self.deref().is_dynamic_fee()
+    }
+
+    fn kind(&self) -> TxKind {
+        self.deref().kind()
+    }
+
+    fn is_create(&self) -> bool {
+        self.deref().is_create()
+    }
+
+    fn value(&self) -> Uint<256, 4> {
+        self.deref().value()
+    }
+
+    fn input(&self) -> &Bytes {
+        self.deref().input()
+    }
+
+    fn access_list(&self) -> Option<&AccessList> {
+        self.deref().access_list()
+    }
+
+    fn blob_versioned_hashes(&self) -> Option<&[B256]> {
+        self.deref().blob_versioned_hashes()
+    }
+
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+        self.deref().authorization_list()
+    }
+}
+
+impl Typed2718 for ScrollTransactionSigned {
+    fn ty(&self) -> u8 {
+        self.deref().ty()
+    }
+}
+
+impl PartialEq for ScrollTransactionSigned {
+    fn eq(&self, other: &Self) -> bool {
+        self.signature == other.signature &&
+            self.transaction == other.transaction &&
+            self.tx_hash() == other.tx_hash()
+    }
+}
+
+impl Hash for ScrollTransactionSigned {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.signature.hash(state);
+        self.transaction.hash(state);
+    }
+}
+
+#[cfg(feature = "reth-codec")]
+impl reth_codecs::Compact for ScrollTransactionSigned {
+    fn to_compact<B>(&self, buf: &mut B) -> usize
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
+    {
+        let start = buf.as_mut().len();
+
+        // Placeholder for bitflags.
+        // The first byte uses 4 bits as flags: IsCompressed[1bit], TxType[2bits], Signature[1bit]
+        buf.put_u8(0);
+
+        let sig_bit = self.signature.to_compact(buf) as u8;
+        let zstd_bit = self.transaction.input().len() >= 32;
+
+        let tx_bits = if zstd_bit {
+            let mut tmp = Vec::with_capacity(256);
+            if cfg!(feature = "std") {
+                reth_zstd_compressors::TRANSACTION_COMPRESSOR.with(|compressor| {
+                    let mut compressor = compressor.borrow_mut();
+                    let tx_bits = self.transaction.to_compact(&mut tmp);
+                    buf.put_slice(&compressor.compress(&tmp).expect("Failed to compress"));
+                    tx_bits as u8
+                })
+            } else {
+                let mut compressor = reth_zstd_compressors::create_tx_compressor();
+                let tx_bits = self.transaction.to_compact(&mut tmp);
+                buf.put_slice(&compressor.compress(&tmp).expect("Failed to compress"));
+                tx_bits as u8
+            }
+        } else {
+            self.transaction.to_compact(buf) as u8
+        };
+
+        // Replace bitflags with the actual values
+        buf.as_mut()[start] = sig_bit | (tx_bits << 1) | ((zstd_bit as u8) << 3);
+
+        buf.as_mut().len() - start
+    }
+
+    fn from_compact(mut buf: &[u8], _len: usize) -> (Self, &[u8]) {
+        use bytes::Buf;
+
+        // The first byte uses 4 bits as flags: IsCompressed[1], TxType[2], Signature[1]
+        let bitflags = buf.get_u8() as usize;
+
+        let sig_bit = bitflags & 1;
+        let (signature, buf) = Signature::from_compact(buf, sig_bit);
+
+        let zstd_bit = bitflags >> 3;
+        let (transaction, buf) = if zstd_bit != 0 {
+            if cfg!(feature = "std") {
+                reth_zstd_compressors::TRANSACTION_DECOMPRESSOR.with(|decompressor| {
+                    let mut decompressor = decompressor.borrow_mut();
+
+                    // TODO: enforce that zstd is only present at a "top" level type
+                    let transaction_type = (bitflags & 0b110) >> 1;
+                    let (transaction, _) = ScrollTypedTransaction::from_compact(
+                        decompressor.decompress(buf),
+                        transaction_type,
+                    );
+
+                    (transaction, buf)
+                })
+            } else {
+                let mut decompressor = reth_zstd_compressors::create_tx_decompressor();
+                let transaction_type = (bitflags & 0b110) >> 1;
+                let (transaction, _) = ScrollTypedTransaction::from_compact(
+                    decompressor.decompress(buf),
+                    transaction_type,
+                );
+
+                (transaction, buf)
+            }
+        } else {
+            let transaction_type = bitflags >> 1;
+            ScrollTypedTransaction::from_compact(buf, transaction_type)
+        };
+
+        (Self { signature, transaction, hash: Default::default() }, buf)
+    }
+}
+
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a> arbitrary::Arbitrary<'a> for ScrollTransactionSigned {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        #[allow(unused_mut)]
+        let mut transaction = ScrollTypedTransaction::arbitrary(u)?;
+
+        let secp = secp256k1::Secp256k1::new();
+        let key_pair = secp256k1::Keypair::new(&secp, &mut rand::thread_rng());
+        let signature = reth_primitives_traits::crypto::secp256k1::sign_message(
+            B256::from_slice(&key_pair.secret_bytes()[..]),
+            signature_hash(&transaction),
+        )
+        .unwrap();
+
+        let signature =
+            if is_l1_message(&transaction) { TxL1Message::signature() } else { signature };
+
+        Ok(Self::new(transaction, signature))
+    }
+}
+
+/// Calculates the signing hash for the transaction.
+fn signature_hash(tx: &ScrollTypedTransaction) -> B256 {
+    match tx {
+        ScrollTypedTransaction::Legacy(tx) => tx.signature_hash(),
+        ScrollTypedTransaction::Eip2930(tx) => tx.signature_hash(),
+        ScrollTypedTransaction::Eip1559(tx) => tx.signature_hash(),
+        ScrollTypedTransaction::L1Message(_) => B256::ZERO,
+    }
+}
+
+/// Returns `true` if transaction is l1 message.
+pub const fn is_l1_message(tx: &ScrollTypedTransaction) -> bool {
+    matches!(tx, ScrollTypedTransaction::L1Message(_))
+}
+
+impl<T: Into<ScrollTypedTransaction>> From<Signed<T>> for ScrollTransactionSigned {
+    fn from(value: Signed<T>) -> Self {
+        let (tx, sig, hash) = value.into_parts();
+        let this = Self::new(tx.into(), sig);
+        this.hash.get_or_init(|| hash);
+        this
+    }
+}
+
+/// Bincode-compatible transaction type serde implementations.
+#[cfg(feature = "serde-bincode-compat")]
+pub mod serde_bincode_compat {
+    use alloc::borrow::Cow;
+    use alloy_consensus::transaction::serde_bincode_compat::{TxEip1559, TxEip2930, TxLegacy};
+    use alloy_primitives::{PrimitiveSignature as Signature, TxHash};
+    use reth_primitives_traits::{serde_bincode_compat::SerdeBincodeCompat, SignedTransaction};
+    use serde::{Deserialize, Serialize};
+
+    /// Bincode-compatible [`super::ScrollTypedTransaction`] serde implementation.
+    #[derive(Debug, Serialize, Deserialize)]
+    #[allow(missing_docs)]
+    enum ScrollTypedTransaction<'a> {
+        Legacy(TxLegacy<'a>),
+        Eip2930(TxEip2930<'a>),
+        Eip1559(TxEip1559<'a>),
+        L1Message(Cow<'a, scroll_alloy_consensus::TxL1Message>),
+    }
+
+    impl<'a> From<&'a super::ScrollTypedTransaction> for ScrollTypedTransaction<'a> {
+        fn from(value: &'a super::ScrollTypedTransaction) -> Self {
+            match value {
+                super::ScrollTypedTransaction::Legacy(tx) => Self::Legacy(TxLegacy::from(tx)),
+                super::ScrollTypedTransaction::Eip2930(tx) => Self::Eip2930(TxEip2930::from(tx)),
+                super::ScrollTypedTransaction::Eip1559(tx) => Self::Eip1559(TxEip1559::from(tx)),
+                super::ScrollTypedTransaction::L1Message(tx) => Self::L1Message(Cow::Borrowed(tx)),
+            }
+        }
+    }
+
+    impl<'a> From<ScrollTypedTransaction<'a>> for super::ScrollTypedTransaction {
+        fn from(value: ScrollTypedTransaction<'a>) -> Self {
+            match value {
+                ScrollTypedTransaction::Legacy(tx) => Self::Legacy(tx.into()),
+                ScrollTypedTransaction::Eip2930(tx) => Self::Eip2930(tx.into()),
+                ScrollTypedTransaction::Eip1559(tx) => Self::Eip1559(tx.into()),
+                ScrollTypedTransaction::L1Message(tx) => Self::L1Message(tx.into_owned()),
+            }
+        }
+    }
+
+    /// Bincode-compatible [`super::ScrollTransactionSigned`] serde implementation.
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct ScrollTransactionSigned<'a> {
+        hash: TxHash,
+        signature: Signature,
+        transaction: ScrollTypedTransaction<'a>,
+    }
+
+    impl<'a> From<&'a super::ScrollTransactionSigned> for ScrollTransactionSigned<'a> {
+        fn from(value: &'a super::ScrollTransactionSigned) -> Self {
+            Self {
+                hash: *value.tx_hash(),
+                signature: value.signature,
+                transaction: ScrollTypedTransaction::from(&value.transaction),
+            }
+        }
+    }
+
+    impl<'a> From<ScrollTransactionSigned<'a>> for super::ScrollTransactionSigned {
+        fn from(value: ScrollTransactionSigned<'a>) -> Self {
+            Self {
+                hash: value.hash.into(),
+                signature: value.signature,
+                transaction: value.transaction.into(),
+            }
+        }
+    }
+
+    impl SerdeBincodeCompat for super::ScrollTransactionSigned {
+        type BincodeRepr<'a> = ScrollTransactionSigned<'a>;
+    }
+}

--- a/crates/scroll/primitives/src/transaction/tx_type.rs
+++ b/crates/scroll/primitives/src/transaction/tx_type.rs
@@ -24,9 +24,9 @@ mod tests {
 
         assert_eq!(
             identifier, expected_identifier,
-            "Unexpected identifier for OpTxType {tx_type:?}",
+            "Unexpected identifier for ScrollTxType {tx_type:?}",
         );
-        assert_eq!(buf, expected_buf, "Unexpected buffer for OpTxType {tx_type:?}",);
+        assert_eq!(buf, expected_buf, "Unexpected buffer for ScrollTxType {tx_type:?}",);
     }
 
     #[rstest]

--- a/crates/scroll/primitives/src/transaction/tx_type.rs
+++ b/crates/scroll/primitives/src/transaction/tx_type.rs
@@ -1,0 +1,47 @@
+//! Scroll transaction type.
+
+pub use scroll_alloy_consensus::ScrollTxType;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reth_codecs::{txtype::*, Compact};
+    use rstest::rstest;
+    use scroll_alloy_consensus::L1_MESSAGE_TX_TYPE_ID;
+
+    #[rstest]
+    #[case(ScrollTxType::Legacy, COMPACT_IDENTIFIER_LEGACY, vec![])]
+    #[case(ScrollTxType::Eip2930, COMPACT_IDENTIFIER_EIP2930, vec![])]
+    #[case(ScrollTxType::Eip1559, COMPACT_IDENTIFIER_EIP1559, vec![])]
+    #[case(ScrollTxType::L1Message, COMPACT_EXTENDED_IDENTIFIER_FLAG, vec![L1_MESSAGE_TX_TYPE_ID])]
+    fn test_txtype_to_compact(
+        #[case] tx_type: ScrollTxType,
+        #[case] expected_identifier: usize,
+        #[case] expected_buf: Vec<u8>,
+    ) {
+        let mut buf = vec![];
+        let identifier = tx_type.to_compact(&mut buf);
+
+        assert_eq!(
+            identifier, expected_identifier,
+            "Unexpected identifier for OpTxType {tx_type:?}",
+        );
+        assert_eq!(buf, expected_buf, "Unexpected buffer for OpTxType {tx_type:?}",);
+    }
+
+    #[rstest]
+    #[case(ScrollTxType::Legacy, COMPACT_IDENTIFIER_LEGACY, vec![])]
+    #[case(ScrollTxType::Eip2930, COMPACT_IDENTIFIER_EIP2930, vec![])]
+    #[case(ScrollTxType::Eip1559, COMPACT_IDENTIFIER_EIP1559, vec![])]
+    #[case(ScrollTxType::L1Message, COMPACT_EXTENDED_IDENTIFIER_FLAG, vec![L1_MESSAGE_TX_TYPE_ID])]
+    fn test_txtype_from_compact(
+        #[case] expected_type: ScrollTxType,
+        #[case] identifier: usize,
+        #[case] buf: Vec<u8>,
+    ) {
+        let (actual_type, remaining_buf) = ScrollTxType::from_compact(&buf, identifier);
+
+        assert_eq!(actual_type, expected_type, "Unexpected TxType for identifier {identifier}");
+        assert!(remaining_buf.is_empty(), "Buffer not fully consumed for identifier {identifier}");
+    }
+}

--- a/crates/storage/codecs/derive/src/compact/mod.rs
+++ b/crates/storage/codecs/derive/src/compact/mod.rs
@@ -200,7 +200,7 @@ fn should_use_alt_impl(ftype: &str, segment: &syn::PathSegment) -> bool {
 pub fn get_bit_size(ftype: &str) -> u8 {
     match ftype {
         "TransactionKind" | "TxKind" | "bool" | "Option" | "Signature" => 1,
-        "TxType" | "OpTxType" => 2,
+        "TxType" | "OpTxType" | "ScrollTxType" => 2,
         "u64" | "BlockNumber" | "TxNumber" | "ChainId" | "NumTransactions" => 4,
         "u128" => 5,
         "U256" => 6,

--- a/crates/storage/storage-api/src/trie.rs
+++ b/crates/storage/storage-api/src/trie.rs
@@ -20,7 +20,7 @@ pub trait StateRootProvider: Send + Sync {
     /// computation.
     fn state_root_from_state(&self, hashed_state: HashedPostState) -> ProviderResult<B256>;
 
-    /// Returns the state root of the `HashedPostState` on top of the current state but re-uses the
+    /// Returns the state root of the `HashedPostState` on top of the current state but reuses the
     /// intermediate nodes to speed up the computation. It's up to the caller to construct the
     /// prefix sets and inform the provider of the trie paths that have changes.
     fn state_root_from_nodes(&self, input: TrieInput) -> ProviderResult<B256>;

--- a/crates/trie/sparse/src/trie.rs
+++ b/crates/trie/sparse/src/trie.rs
@@ -2246,7 +2246,7 @@ mod tests {
     /// different prefix: 0x0100. Hash builder trie has only the first two leaves, and we have
     /// proofs for them.
     ///
-    /// 1. Insert the leaf 0x0100 into the sparse trie, and check that the root extensino node was
+    /// 1. Insert the leaf 0x0100 into the sparse trie, and check that the root extension node was
     ///    turned into a branch node.
     /// 2. Reveal the leaf 0x0001 in the sparse trie, and check that the root branch node wasn't
     ///    overwritten with the extension node from the proof.


### PR DESCRIPTION
Adds the `reth-scroll-primitives` crate that will be used in order to build the `ScrollPrimitives` for the Node. The `ScrollPrimitives` will be added as the `Primitives` GAT of the `NodeTypes` for the `ScrollNode` in a subsequent PR.