### PR TITLE
feat: update scroll payload attributes

### DIFF
--- a/crates/engine/local/src/payload.rs
+++ b/crates/engine/local/src/payload.rs
@@ -75,6 +75,7 @@ where
             payload_attributes: self.build(timestamp),
             transactions: None,
             no_tx_pool: false,
+            block_data_hint: None,
         }
     }
 }

--- a/crates/scroll/alloy/rpc-types-engine/src/lib.rs
+++ b/crates/scroll/alloy/rpc-types-engine/src/lib.rs
@@ -3,6 +3,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 mod attributes;
-pub use attributes::ScrollPayloadAttributes;
+pub use attributes::{BlockDataHint, ScrollPayloadAttributes};
 
 extern crate alloc;

--- a/crates/scroll/engine-primitives/src/payload/attributes.rs
+++ b/crates/scroll/engine-primitives/src/payload/attributes.rs
@@ -169,7 +169,7 @@ mod tests {
     #[test]
     fn test_payload_id() {
         let expected =
-            PayloadId::new(FixedBytes::<8>::from_str("0x03aa2163b02acd8a").unwrap().into());
+            PayloadId::new(FixedBytes::<8>::from_str("0x0322b5f17cf26e85").unwrap().into());
         let attrs = ScrollPayloadAttributes {
             payload_attributes: PayloadAttributes {
                 timestamp: 1728933301,

--- a/crates/scroll/engine-primitives/src/payload/attributes.rs
+++ b/crates/scroll/engine-primitives/src/payload/attributes.rs
@@ -11,7 +11,7 @@ use reth_payload_builder::EthPayloadBuilderAttributes;
 use reth_payload_primitives::PayloadBuilderAttributes;
 use reth_primitives::transaction::WithEncoded;
 use reth_scroll_primitives::ScrollTransactionSigned;
-use scroll_alloy_rpc_types_engine::ScrollPayloadAttributes;
+use scroll_alloy_rpc_types_engine::{BlockDataHint, ScrollPayloadAttributes};
 
 /// Scroll Payload Builder Attributes
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -23,6 +23,9 @@ pub struct ScrollPayloadBuilderAttributes {
     /// Decoded transactions and the original EIP-2718 encoded bytes as received in the payload
     /// attributes.
     pub transactions: Vec<WithEncoded<ScrollTransactionSigned>>,
+    /// The pre-Euclid block data hint, necessary for the block builder to derive the correct block
+    /// hash.
+    pub block_data_hint: Option<BlockDataHint>,
 }
 
 impl PayloadBuilderAttributes for ScrollPayloadBuilderAttributes {
@@ -62,7 +65,12 @@ impl PayloadBuilderAttributes for ScrollPayloadBuilderAttributes {
             parent_beacon_block_root: attributes.payload_attributes.parent_beacon_block_root,
         };
 
-        Ok(Self { payload_attributes, no_tx_pool: attributes.no_tx_pool, transactions })
+        Ok(Self {
+            payload_attributes,
+            no_tx_pool: attributes.no_tx_pool,
+            transactions,
+            block_data_hint: attributes.block_data_hint,
+        })
     }
 
     fn payload_id(&self) -> PayloadId {
@@ -134,6 +142,11 @@ pub(crate) fn payload_id_scroll(
         }
     }
 
+    if let Some(block_data) = &attributes.block_data_hint {
+        hasher.update(&block_data.extra_data);
+        hasher.update(block_data.difficulty.to_be_bytes::<32>());
+    }
+
     let mut out = hasher.finalize();
     out[0] = payload_version;
     PayloadId::new(out.as_slice()[..8].try_into().expect("sufficient length"))
@@ -149,7 +162,7 @@ impl From<EthPayloadBuilderAttributes> for ScrollPayloadBuilderAttributes {
 mod tests {
     use super::*;
     use alloc::str::FromStr;
-    use alloy_primitives::{address, b256, bytes, FixedBytes};
+    use alloy_primitives::{address, b256, bytes, FixedBytes, U256};
     use alloy_rpc_types_engine::PayloadAttributes;
     use reth_payload_primitives::EngineApiMessageVersion;
 
@@ -167,6 +180,7 @@ mod tests {
             },
             transactions: Some([bytes!("7ef8f8a0dc19cfa777d90980e4875d0a548a881baaa3f83f14d1bc0d3038bc329350e54194deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e20000f424000000000000000000000000300000000670d6d890000000000000125000000000000000000000000000000000000000000000000000000000000000700000000000000000000000000000000000000000000000000000000000000014bf9181db6e381d4384bbf69c48b0ee0eed23c6ca26143c6d2544f9d39997a590000000000000000000000007f83d659683caf2767fd3c720981d51f5bc365bc")].into()),
             no_tx_pool: false,
+            block_data_hint: Some(BlockDataHint{ extra_data: bytes!("476574682f76312e302e302f6c696e75782f676f312e342e32"), difficulty: U256::from(10) } ),
         };
 
         assert_eq!(

--- a/crates/scroll/evm/src/build.rs
+++ b/crates/scroll/evm/src/build.rs
@@ -2,7 +2,7 @@ use alloc::sync::Arc;
 use alloy_consensus::{proofs, BlockBody, Header, TxReceipt, EMPTY_OMMER_ROOT_HASH};
 use alloy_eips::merge::BEACON_NONCE;
 use alloy_evm::block::{BlockExecutionError, BlockExecutorFactory};
-use alloy_primitives::logs_bloom;
+use alloy_primitives::{logs_bloom, Address};
 use reth_evm::execute::{BlockAssembler, BlockAssemblerInput};
 use reth_execution_types::BlockExecutionResult;
 use reth_primitives_traits::SignedTransaction;
@@ -62,7 +62,7 @@ where
         let header = Header {
             parent_hash: ctx.parent_hash,
             ommers_hash: EMPTY_OMMER_ROOT_HASH,
-            beneficiary: evm_env.block_env.beneficiary,
+            beneficiary: Address::ZERO,
             state_root,
             transactions_root,
             receipts_root,
@@ -71,7 +71,10 @@ where
             timestamp,
             mix_hash: evm_env.block_env.prevrandao.unwrap_or_default(),
             nonce: BEACON_NONCE.into(),
-            base_fee_per_gas: Some(evm_env.block_env.basefee),
+            base_fee_per_gas: self
+                .chain_spec
+                .is_curie_active_at_block(evm_env.block_env.number)
+                .then_some(evm_env.block_env.basefee),
             number: evm_env.block_env.number,
             gas_limit: evm_env.block_env.gas_limit,
             difficulty: evm_env.block_env.difficulty,

--- a/crates/scroll/node/src/test_utils.rs
+++ b/crates/scroll/node/src/test_utils.rs
@@ -77,5 +77,6 @@ pub fn scroll_payload_attributes(timestamp: u64) -> ScrollPayloadBuilderAttribut
         payload_attributes: EthPayloadBuilderAttributes::new(B256::ZERO, attributes),
         transactions: vec![],
         no_tx_pool: false,
+        block_data_hint: None,
     }
 }


### PR DESCRIPTION
Updates the scroll payload attributes, adding a `block_data_hint` field which is used in block building tasks in order to inject data in the built block (in this case the `extra_data` and `difficulty` fields).