### PR TITLE
feat: Sequencer RN Integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.3.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71b0b181c956dca015b4c08b36668736013787c9dc9e743fd39a23b8b130c14"
+checksum = "e158fd08c4be4fafe8c9fb7cb661f3b9585038446df0cd20b3d99e71f4166748"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11337,6 +11337,7 @@ dependencies = [
 name = "scroll-alloy-provider"
 version = "1.3.4"
 dependencies = [
+ "alloy-json-rpc",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-client",
@@ -11348,6 +11349,8 @@ dependencies = [
  "eyre",
  "futures-util",
  "http-body-util",
+ "jsonrpsee",
+ "jsonrpsee-types",
  "reqwest",
  "reth-engine-primitives",
  "reth-payload-builder",
@@ -11368,6 +11371,7 @@ dependencies = [
  "reth-transaction-pool",
  "scroll-alloy-network",
  "scroll-alloy-rpc-types-engine",
+ "thiserror 2.0.12",
  "tokio",
  "tower 0.4.13",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e158fd08c4be4fafe8c9fb7cb661f3b9585038446df0cd20b3d99e71f4166748"
+checksum = "b71b0b181c956dca015b4c08b36668736013787c9dc9e743fd39a23b8b130c14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2271,7 +2271,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2735,7 +2735,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e4fdb82bd54a12e42fb58a800dcae6b9e13982238ce2296dc3570b92148e1f"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3200,7 +3200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4834,7 +4834,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.0",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5188,7 +5188,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6587,7 +6587,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10968,7 +10968,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10981,7 +10981,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11047,7 +11047,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11964,7 +11964,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix 1.0.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12538,7 +12538,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fff37da548239c3bf9e64a12193d261e8b22b660991c6fd2df057c168f435f"
 dependencies = [
  "cc",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -13052,7 +13052,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11355,6 +11355,7 @@ dependencies = [
  "reth-primitives",
  "reth-primitives-traits",
  "reth-provider",
+ "reth-rpc-api",
  "reth-rpc-builder",
  "reth-rpc-engine-api",
  "reth-scroll-chainspec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -476,7 +476,7 @@ revm-inspectors = "0.18.0"
 alloy-chains = { version = "0.1.68", default-features = false }
 alloy-dyn-abi = "0.8.25"
 alloy-eip2124 = { version = "0.1.0", default-features = false }
-alloy-evm = { version = "0.3.2", default-features = false }
+alloy-evm = { version = "=0.3.1", default-features = false }
 alloy-primitives = { version = "0.8.25", default-features = false, features = ["map-foldhash"] }
 alloy-rlp = { version = "0.3.10", default-features = false, features = ["core-net"] }
 alloy-sol-types = { version = "0.8.25", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -476,7 +476,7 @@ revm-inspectors = "0.18.0"
 alloy-chains = { version = "0.1.68", default-features = false }
 alloy-dyn-abi = "0.8.25"
 alloy-eip2124 = { version = "0.1.0", default-features = false }
-alloy-evm = { version = "0.3.1", default-features = false }
+alloy-evm = { version = "0.3.2", default-features = false }
 alloy-primitives = { version = "0.8.25", default-features = false, features = ["map-foldhash"] }
 alloy-rlp = { version = "0.3.10", default-features = false, features = ["core-net"] }
 alloy-sol-types = { version = "0.8.25", default-features = false }

--- a/crates/scroll/alloy/evm/src/block/mod.rs
+++ b/crates/scroll/alloy/evm/src/block/mod.rs
@@ -214,6 +214,10 @@ where
     fn evm_mut(&mut self) -> &mut Self::Evm {
         &mut self.evm
     }
+
+    fn evm(&self) -> &Self::Evm {
+        &self.evm
+    }
 }
 
 /// An extension of the [`Evm`] trait for Scroll.

--- a/crates/scroll/alloy/evm/src/block/mod.rs
+++ b/crates/scroll/alloy/evm/src/block/mod.rs
@@ -214,10 +214,6 @@ where
     fn evm_mut(&mut self) -> &mut Self::Evm {
         &mut self.evm
     }
-
-    fn evm(&self) -> &Self::Evm {
-        &self.evm
-    }
 }
 
 /// An extension of the [`Evm`] trait for Scroll.

--- a/crates/scroll/alloy/provider/Cargo.toml
+++ b/crates/scroll/alloy/provider/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 # alloy
+alloy-json-rpc.workspace = true
 alloy-provider.workspace = true
 alloy-primitives.workspace = true
 alloy-rpc-types-engine = { workspace = true, features = ["serde"] }
@@ -37,6 +38,9 @@ eyre.workspace = true
 http-body-util.workspace = true
 reqwest.workspace = true
 tower.workspace = true
+thiserror.workspace = true
+jsonrpsee.workspace = true
+jsonrpsee-types.workspace = true
 
 [dev-dependencies]
 reth-payload-builder = { workspace = true, features = ["test-utils"] }

--- a/crates/scroll/alloy/provider/Cargo.toml
+++ b/crates/scroll/alloy/provider/Cargo.toml
@@ -26,7 +26,7 @@ scroll-alloy-network.workspace = true
 scroll-alloy-rpc-types-engine = { workspace = true, features = ["serde"] }
 
 # reth
-reth-rpc-api.workspace = true
+reth-rpc-api = { workspace = true, features = ["client"] }
 
 # reth-scroll
 reth-scroll-engine-primitives.workspace = true

--- a/crates/scroll/alloy/provider/Cargo.toml
+++ b/crates/scroll/alloy/provider/Cargo.toml
@@ -65,14 +65,15 @@ futures-util.workspace = true
 [features]
 default = ["std"]
 std = [
-    "alloy-primitives/std",
-    "alloy-rpc-types-engine/std",
-    "scroll-alloy-rpc-types-engine/std",
-    "derive_more/std",
-    "reth-engine-primitives/std",
-    "reth-primitives/std",
-    "reth-primitives-traits/std",
-    "reth-scroll-payload/std",
-    "futures-util/std",
-    "reth-scroll-chainspec/std",
+	"alloy-primitives/std",
+	"alloy-rpc-types-engine/std",
+	"scroll-alloy-rpc-types-engine/std",
+	"derive_more/std",
+	"reth-engine-primitives/std",
+	"reth-primitives/std",
+	"reth-primitives-traits/std",
+	"reth-scroll-payload/std",
+	"futures-util/std",
+	"reth-scroll-chainspec/std",
+	"thiserror/std"
 ]

--- a/crates/scroll/alloy/provider/Cargo.toml
+++ b/crates/scroll/alloy/provider/Cargo.toml
@@ -65,15 +65,15 @@ futures-util.workspace = true
 [features]
 default = ["std"]
 std = [
-	"alloy-primitives/std",
-	"alloy-rpc-types-engine/std",
-	"scroll-alloy-rpc-types-engine/std",
-	"derive_more/std",
-	"reth-engine-primitives/std",
-	"reth-primitives/std",
-	"reth-primitives-traits/std",
-	"reth-scroll-payload/std",
-	"futures-util/std",
-	"reth-scroll-chainspec/std",
-	"thiserror/std"
+    "alloy-primitives/std",
+    "alloy-rpc-types-engine/std",
+    "scroll-alloy-rpc-types-engine/std",
+    "derive_more/std",
+    "reth-engine-primitives/std",
+    "reth-primitives/std",
+    "reth-primitives-traits/std",
+    "reth-scroll-payload/std",
+    "futures-util/std",
+    "reth-scroll-chainspec/std",
+    "thiserror/std",
 ]

--- a/crates/scroll/alloy/provider/Cargo.toml
+++ b/crates/scroll/alloy/provider/Cargo.toml
@@ -24,6 +24,12 @@ alloy-transport-http = { workspace = true, features = ["jwt-auth"] }
 scroll-alloy-network.workspace = true
 scroll-alloy-rpc-types-engine = { workspace = true, features = ["serde"] }
 
+# reth
+reth-rpc-api.workspace = true
+
+# reth-scroll
+reth-scroll-engine-primitives.workspace = true
+
 # misc
 async-trait.workspace = true
 derive_more.workspace = true

--- a/crates/scroll/alloy/provider/src/engine/client.rs
+++ b/crates/scroll/alloy/provider/src/engine/client.rs
@@ -1,0 +1,79 @@
+use super::{ScrollEngineApi, ScrollEngineApiResult};
+use alloy_primitives::{BlockHash, U64};
+use alloy_rpc_types_engine::{
+    ClientVersionV1, ExecutionPayloadBodiesV1, ExecutionPayloadV1, ForkchoiceState,
+    ForkchoiceUpdated, PayloadId, PayloadStatus,
+};
+
+use reth_rpc_api::EngineApiClient;
+use reth_scroll_engine_primitives::ScrollEngineTypes;
+use scroll_alloy_rpc_types_engine::ScrollPayloadAttributes;
+
+/// A Client for a type that implements the [`EngineApiClient`] trait.
+#[derive(Debug)]
+pub struct ScrollAuthApiEngineClient<T> {
+    client: T,
+}
+
+impl<T> ScrollAuthApiEngineClient<T> {
+    /// Creates a new [`ScrollAuthApiEngineClient`] with the given client.
+    pub fn new(client: T) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait::async_trait]
+impl<EC: EngineApiClient<ScrollEngineTypes> + Sync> ScrollEngineApi
+    for ScrollAuthApiEngineClient<EC>
+{
+    async fn new_payload_v1(
+        &self,
+        payload: ExecutionPayloadV1,
+    ) -> ScrollEngineApiResult<PayloadStatus> {
+        Ok(self.client.new_payload_v1(payload).await?)
+    }
+
+    async fn fork_choice_updated_v1(
+        &self,
+        fork_choice_state: ForkchoiceState,
+        payload_attributes: Option<ScrollPayloadAttributes>,
+    ) -> ScrollEngineApiResult<ForkchoiceUpdated> {
+        Ok(self.client.fork_choice_updated_v1(fork_choice_state, payload_attributes).await?)
+    }
+
+    async fn get_payload_v1(
+        &self,
+        payload_id: PayloadId,
+    ) -> ScrollEngineApiResult<ExecutionPayloadV1> {
+        Ok(self.client.get_payload_v1(payload_id).await?)
+    }
+
+    async fn get_payload_bodies_by_hash_v1(
+        &self,
+        block_hashes: Vec<BlockHash>,
+    ) -> ScrollEngineApiResult<ExecutionPayloadBodiesV1> {
+        Ok(self.client.get_payload_bodies_by_hash_v1(block_hashes).await?)
+    }
+
+    async fn get_payload_bodies_by_range_v1(
+        &self,
+        start: U64,
+        count: U64,
+    ) -> ScrollEngineApiResult<ExecutionPayloadBodiesV1> {
+        Ok(self.client.get_payload_bodies_by_range_v1(start, count).await?)
+    }
+
+    async fn get_client_version_v1(
+        &self,
+        client_version: ClientVersionV1,
+    ) -> ScrollEngineApiResult<Vec<ClientVersionV1>> {
+        Ok(self.client.get_client_version_v1(client_version).await?)
+    }
+
+    async fn exchange_capabilities(
+        &self,
+        capabilities: Vec<String>,
+    ) -> ScrollEngineApiResult<Vec<String>> {
+        Ok(self.exchange_capabilities(capabilities).await?)
+    }
+}

--- a/crates/scroll/alloy/provider/src/engine/mod.rs
+++ b/crates/scroll/alloy/provider/src/engine/mod.rs
@@ -15,7 +15,7 @@ use scroll_alloy_rpc_types_engine::ScrollPayloadAttributes;
 /// Note:
 /// > The provider should use a JWT authentication layer.
 #[async_trait::async_trait]
-pub trait ScrollEngineApi<N> {
+pub trait ScrollEngineApi {
     /// See also <https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/paris.md#engine_newpayloadv1>
     /// Caution: This should not accept the `withdrawals` field
     async fn new_payload_v1(&self, payload: ExecutionPayloadV1) -> TransportResult<PayloadStatus>;
@@ -92,10 +92,9 @@ pub trait ScrollEngineApi<N> {
 }
 
 #[async_trait::async_trait]
-impl<N, P> ScrollEngineApi<N> for P
+impl<P> ScrollEngineApi for P
 where
-    N: Network,
-    P: Provider<N>,
+    P: Provider<scroll_alloy_network::Scroll>,
 {
     async fn new_payload_v1(&self, payload: ExecutionPayloadV1) -> TransportResult<PayloadStatus> {
         self.client().request("engine_newPayloadV1", (payload,)).await

--- a/crates/scroll/alloy/provider/src/engine/mod.rs
+++ b/crates/scroll/alloy/provider/src/engine/mod.rs
@@ -2,14 +2,20 @@ mod provider;
 
 pub use provider::ScrollAuthEngineApiProvider;
 
+mod client;
+pub use client::ScrollAuthApiEngineClient;
+
+use super::error::ScrollEngineApiError;
 use alloy_primitives::{BlockHash, U64};
-use alloy_provider::{Network, Provider};
 use alloy_rpc_types_engine::{
     ClientVersionV1, ExecutionPayloadBodiesV1, ExecutionPayloadV1, ForkchoiceState,
     ForkchoiceUpdated, PayloadId, PayloadStatus,
 };
-use alloy_transport::TransportResult;
+
 use scroll_alloy_rpc_types_engine::ScrollPayloadAttributes;
+
+/// A type alias for the result of the Scroll Engine API methods.
+pub type ScrollEngineApiResult<T> = Result<T, ScrollEngineApiError>;
 
 /// Engine API trait for Scroll. Only exposes versions of the API that are supported.
 /// Note:
@@ -18,7 +24,10 @@ use scroll_alloy_rpc_types_engine::ScrollPayloadAttributes;
 pub trait ScrollEngineApi {
     /// See also <https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/paris.md#engine_newpayloadv1>
     /// Caution: This should not accept the `withdrawals` field
-    async fn new_payload_v1(&self, payload: ExecutionPayloadV1) -> TransportResult<PayloadStatus>;
+    async fn new_payload_v1(
+        &self,
+        payload: ExecutionPayloadV1,
+    ) -> ScrollEngineApiResult<PayloadStatus>;
 
     /// See also <https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/paris.md#engine_forkchoiceupdatedv1>
     /// Caution: This should not accept the `withdrawals` field in the payload attributes.
@@ -32,7 +41,7 @@ pub trait ScrollEngineApi {
         &self,
         fork_choice_state: ForkchoiceState,
         payload_attributes: Option<ScrollPayloadAttributes>,
-    ) -> TransportResult<ForkchoiceUpdated>;
+    ) -> ScrollEngineApiResult<ForkchoiceUpdated>;
 
     /// See also <https://github.com/ethereum/execution-apis/blob/6709c2a795b707202e93c4f2867fa0bf2640a84f/src/engine/paris.md#engine_getpayloadv1>
     ///
@@ -43,13 +52,16 @@ pub trait ScrollEngineApi {
     ///
     /// Note:
     /// > Provider software MAY stop the corresponding build process after serving this call.
-    async fn get_payload_v1(&self, payload_id: PayloadId) -> TransportResult<ExecutionPayloadV1>;
+    async fn get_payload_v1(
+        &self,
+        payload_id: PayloadId,
+    ) -> ScrollEngineApiResult<ExecutionPayloadV1>;
 
     /// See also <https://github.com/ethereum/execution-apis/blob/6452a6b194d7db269bf1dbd087a267251d3cc7f8/src/engine/shanghai.md#engine_getpayloadbodiesbyhashv1>
     async fn get_payload_bodies_by_hash_v1(
         &self,
         block_hashes: Vec<BlockHash>,
-    ) -> TransportResult<ExecutionPayloadBodiesV1>;
+    ) -> ScrollEngineApiResult<ExecutionPayloadBodiesV1>;
 
     /// See also <https://github.com/ethereum/execution-apis/blob/6452a6b194d7db269bf1dbd087a267251d3cc7f8/src/engine/shanghai.md#engine_getpayloadbodiesbyrangev1>
     ///
@@ -67,7 +79,7 @@ pub trait ScrollEngineApi {
         &self,
         start: U64,
         count: U64,
-    ) -> TransportResult<ExecutionPayloadBodiesV1>;
+    ) -> ScrollEngineApiResult<ExecutionPayloadBodiesV1>;
 
     /// This function will return the ClientVersionV1 object.
     /// See also:
@@ -82,64 +94,11 @@ pub trait ScrollEngineApi {
     async fn get_client_version_v1(
         &self,
         client_version: ClientVersionV1,
-    ) -> TransportResult<Vec<ClientVersionV1>>;
+    ) -> ScrollEngineApiResult<Vec<ClientVersionV1>>;
 
     /// See also <https://github.com/ethereum/execution-apis/blob/6452a6b194d7db269bf1dbd087a267251d3cc7f8/src/engine/common.md#capabilities>
     async fn exchange_capabilities(
         &self,
         capabilities: Vec<String>,
-    ) -> TransportResult<Vec<String>>;
-}
-
-#[async_trait::async_trait]
-impl<P> ScrollEngineApi for P
-where
-    P: Provider<scroll_alloy_network::Scroll>,
-{
-    async fn new_payload_v1(&self, payload: ExecutionPayloadV1) -> TransportResult<PayloadStatus> {
-        self.client().request("engine_newPayloadV1", (payload,)).await
-    }
-
-    async fn fork_choice_updated_v1(
-        &self,
-        fork_choice_state: ForkchoiceState,
-        payload_attributes: Option<ScrollPayloadAttributes>,
-    ) -> TransportResult<ForkchoiceUpdated> {
-        self.client()
-            .request("engine_forkchoiceUpdatedV1", (fork_choice_state, payload_attributes))
-            .await
-    }
-
-    async fn get_payload_v1(&self, payload_id: PayloadId) -> TransportResult<ExecutionPayloadV1> {
-        self.client().request("engine_getPayloadV1", (payload_id,)).await
-    }
-
-    async fn get_payload_bodies_by_hash_v1(
-        &self,
-        block_hashes: Vec<BlockHash>,
-    ) -> TransportResult<ExecutionPayloadBodiesV1> {
-        self.client().request("engine_getPayloadBodiesByHashV1", (block_hashes,)).await
-    }
-
-    async fn get_payload_bodies_by_range_v1(
-        &self,
-        start: U64,
-        count: U64,
-    ) -> TransportResult<ExecutionPayloadBodiesV1> {
-        self.client().request("engine_getPayloadBodiesByRangeV1", (start, count)).await
-    }
-
-    async fn get_client_version_v1(
-        &self,
-        client_version: ClientVersionV1,
-    ) -> TransportResult<Vec<ClientVersionV1>> {
-        self.client().request("engine_getClientVersionV1", (client_version,)).await
-    }
-
-    async fn exchange_capabilities(
-        &self,
-        capabilities: Vec<String>,
-    ) -> TransportResult<Vec<String>> {
-        self.client().request("engine_exchangeCapabilities", (capabilities,)).await
-    }
+    ) -> ScrollEngineApiResult<Vec<String>>;
 }

--- a/crates/scroll/alloy/provider/src/engine/provider.rs
+++ b/crates/scroll/alloy/provider/src/engine/provider.rs
@@ -1,12 +1,12 @@
-use super::ScrollEngineApi;
+use super::{ScrollEngineApi, ScrollEngineApiResult};
 use alloy_primitives::{bytes::Bytes, BlockHash, U64};
-use alloy_provider::{Network, RootProvider};
+use alloy_provider::{Network, Provider, RootProvider};
 use alloy_rpc_client::RpcClient;
 use alloy_rpc_types_engine::{
     ClientVersionV1, ExecutionPayloadBodiesV1, ExecutionPayloadV1, ForkchoiceState,
     ForkchoiceUpdated, JwtSecret, PayloadId, PayloadStatus,
 };
-use alloy_transport::{utils::guess_local_url, TransportResult};
+use alloy_transport::utils::guess_local_url;
 use alloy_transport_http::{
     hyper_util, hyper_util::rt::TokioExecutor, AuthLayer, Http, HyperClient,
 };
@@ -44,49 +44,58 @@ impl ScrollAuthEngineApiProvider {
 
 #[async_trait::async_trait]
 impl ScrollEngineApi for ScrollAuthEngineApiProvider {
-    async fn new_payload_v1(&self, payload: ExecutionPayloadV1) -> TransportResult<PayloadStatus> {
-        self.auth_provider.new_payload_v1(payload).await
+    async fn new_payload_v1(
+        &self,
+        payload: ExecutionPayloadV1,
+    ) -> ScrollEngineApiResult<PayloadStatus> {
+        Ok(self.auth_provider.client().request("engine_newPayloadV1", (payload,)).await?)
     }
 
     async fn fork_choice_updated_v1(
         &self,
         fork_choice_state: ForkchoiceState,
         payload_attributes: Option<ScrollPayloadAttributes>,
-    ) -> TransportResult<ForkchoiceUpdated> {
-        self.auth_provider.fork_choice_updated_v1(fork_choice_state, payload_attributes).await
+    ) -> ScrollEngineApiResult<ForkchoiceUpdated> {
+        Ok(self
+            .client()
+            .request("engine_forkchoiceUpdatedV1", (fork_choice_state, payload_attributes))
+            .await?)
     }
 
-    async fn get_payload_v1(&self, payload_id: PayloadId) -> TransportResult<ExecutionPayloadV1> {
-        self.auth_provider.get_payload_v1(payload_id).await
+    async fn get_payload_v1(
+        &self,
+        payload_id: PayloadId,
+    ) -> ScrollEngineApiResult<ExecutionPayloadV1> {
+        Ok(self.client().request("engine_getPayloadV1", (payload_id,)).await?)
     }
 
     async fn get_payload_bodies_by_hash_v1(
         &self,
         block_hashes: Vec<BlockHash>,
-    ) -> TransportResult<ExecutionPayloadBodiesV1> {
-        self.auth_provider.get_payload_bodies_by_hash_v1(block_hashes).await
+    ) -> ScrollEngineApiResult<ExecutionPayloadBodiesV1> {
+        Ok(self.client().request("engine_getPayloadBodiesByHashV1", (block_hashes,)).await?)
     }
 
     async fn get_payload_bodies_by_range_v1(
         &self,
         start: U64,
         count: U64,
-    ) -> TransportResult<ExecutionPayloadBodiesV1> {
-        self.auth_provider.get_payload_bodies_by_range_v1(start, count).await
+    ) -> ScrollEngineApiResult<ExecutionPayloadBodiesV1> {
+        Ok(self.client().request("engine_getPayloadBodiesByRangeV1", (start, count)).await?)
     }
 
     async fn get_client_version_v1(
         &self,
         client_version: ClientVersionV1,
-    ) -> TransportResult<Vec<ClientVersionV1>> {
-        self.auth_provider.get_client_version_v1(client_version).await
+    ) -> ScrollEngineApiResult<Vec<ClientVersionV1>> {
+        Ok(self.client().request("engine_getClientVersionV1", (client_version,)).await?)
     }
 
     async fn exchange_capabilities(
         &self,
         capabilities: Vec<String>,
-    ) -> TransportResult<Vec<String>> {
-        self.auth_provider.exchange_capabilities(capabilities).await
+    ) -> ScrollEngineApiResult<Vec<String>> {
+        Ok(self.client().request("engine_exchangeCapabilities", (capabilities,)).await?)
     }
 }
 

--- a/crates/scroll/alloy/provider/src/engine/provider.rs
+++ b/crates/scroll/alloy/provider/src/engine/provider.rs
@@ -43,7 +43,7 @@ impl ScrollAuthEngineApiProvider {
 }
 
 #[async_trait::async_trait]
-impl ScrollEngineApi<scroll_alloy_network::Scroll> for ScrollAuthEngineApiProvider {
+impl ScrollEngineApi for ScrollAuthEngineApiProvider {
     async fn new_payload_v1(&self, payload: ExecutionPayloadV1) -> TransportResult<PayloadStatus> {
         self.auth_provider.new_payload_v1(payload).await
     }

--- a/crates/scroll/alloy/provider/src/error.rs
+++ b/crates/scroll/alloy/provider/src/error.rs
@@ -1,0 +1,10 @@
+/// The error type for the Scroll engine API.
+#[derive(thiserror::Error, Debug)]
+pub enum ScrollEngineApiError {
+    /// Error when decoding a response from an rpsee client.
+    #[error("Jsonrpsee error: {0}")]
+    JsonRpseeError(#[from] jsonrpsee::core::ClientError),
+    /// Error when decoding a response from an alloy client.
+    #[error("Alloy error: {0}")]
+    AlloyError(#[from] alloy_transport::TransportError),
+}

--- a/crates/scroll/alloy/provider/src/lib.rs
+++ b/crates/scroll/alloy/provider/src/lib.rs
@@ -1,4 +1,9 @@
 //! Providers implementations fitted to Scroll needs.
 
 mod engine;
-pub use engine::{ScrollAuthEngineApiProvider, ScrollEngineApi};
+pub use engine::{
+    ScrollAuthApiEngineClient, ScrollAuthEngineApiProvider, ScrollEngineApi, ScrollEngineApiResult,
+};
+
+mod error;
+pub use error::ScrollEngineApiError;


### PR DESCRIPTION
# Overview
This PR modifies the `alloy-provider` crate to support a `jsonrpsee` client type. Upon review and consideration, I think that this is the wrong direction to take. Instead, we should introduce a new trait in `rollup-node-provider`s which is analogous to `ScrollEngineApi` and do the wrapping to support both `alloy` and `jsonrpsee` clients there. However, in the name of practicality and progress I suggest we merge this as is for now and then open an issue to move this in milestone 5.