### PR TITLE
feat: configure block gas limit

### DIFF
--- a/crates/scroll/node/src/builder/payload.rs
+++ b/crates/scroll/node/src/builder/payload.rs
@@ -1,11 +1,13 @@
 use reth_evm::ConfigureEvm;
 use reth_node_api::PrimitivesTy;
-use reth_node_builder::{components::PayloadBuilderBuilder, BuilderContext, FullNodeTypes};
+use reth_node_builder::{
+    components::PayloadBuilderBuilder, BuilderContext, FullNodeTypes, PayloadBuilderConfig,
+};
 use reth_node_types::{NodeTypes, TxTy};
 use reth_scroll_chainspec::ScrollChainSpec;
 use reth_scroll_engine_primitives::ScrollEngineTypes;
 use reth_scroll_evm::ScrollNextBlockEnvAttributes;
-use reth_scroll_payload::ScrollPayloadTransactions;
+use reth_scroll_payload::{ScrollBuilderConfig, ScrollPayloadTransactions};
 use reth_scroll_primitives::{ScrollPrimitives, ScrollTransactionSigned};
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
 
@@ -43,6 +45,7 @@ impl<Txs> ScrollPayloadBuilder<Txs> {
             pool,
             evm_config,
             ctx.provider().clone(),
+            ScrollBuilderConfig::new(ctx.payload_builder_config().gas_limit()),
         )
         .with_transactions(self.best_transactions);
 

--- a/crates/scroll/payload/src/builder.rs
+++ b/crates/scroll/payload/src/builder.rs
@@ -1,6 +1,8 @@
 //! Scroll's payload builder implementation.
 
 use super::{PayloadBuildingBaseFeeProvider, ScrollPayloadBuilderError};
+use crate::config::ScrollBuilderConfig;
+
 use alloy_consensus::{Transaction, Typed2718};
 use alloy_primitives::{B256, U256};
 use alloy_rlp::Encodable;
@@ -67,12 +69,19 @@ pub struct ScrollPayloadBuilder<Pool, Client, Evm, Txs = ()> {
     pub client: Client,
     /// The type responsible for yielding the best transactions to include in a payload.
     pub best_transactions: Txs,
+    /// Payload builder configuration.
+    pub builder_config: ScrollBuilderConfig,
 }
 
 impl<Pool, Evm, Client> ScrollPayloadBuilder<Pool, Client, Evm> {
     /// Creates a new [`ScrollPayloadBuilder`].
-    pub const fn new(pool: Pool, evm_config: Evm, client: Client) -> Self {
-        Self { evm_config, pool, client, best_transactions: () }
+    pub const fn new(
+        pool: Pool,
+        evm_config: Evm,
+        client: Client,
+        builder_config: ScrollBuilderConfig,
+    ) -> Self {
+        Self { evm_config, pool, client, best_transactions: (), builder_config }
     }
 }
 
@@ -83,8 +92,8 @@ impl<Pool, Client, Evm, Txs> ScrollPayloadBuilder<Pool, Client, Evm, Txs> {
         self,
         best_transactions: T,
     ) -> ScrollPayloadBuilder<Pool, Client, Evm, T> {
-        let Self { evm_config, pool, client, .. } = self;
-        ScrollPayloadBuilder { evm_config, pool, client, best_transactions }
+        let Self { evm_config, pool, client, builder_config, .. } = self;
+        ScrollPayloadBuilder { evm_config, pool, client, best_transactions, builder_config }
     }
 }
 

--- a/crates/scroll/payload/src/config.rs
+++ b/crates/scroll/payload/src/config.rs
@@ -1,0 +1,15 @@
+//! Configuration for the payload builder.
+
+/// Settings for the Scroll builder.
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct ScrollBuilderConfig {
+    /// Desired gas limit.
+    pub desired_gas_limit: u64,
+}
+
+impl ScrollBuilderConfig {
+    /// Returns a new instance of [`ScrollBuilderConfig`].
+    pub const fn new(desired_gas_limit: u64) -> Self {
+        Self { desired_gas_limit }
+    }
+}

--- a/crates/scroll/payload/src/lib.rs
+++ b/crates/scroll/payload/src/lib.rs
@@ -13,6 +13,9 @@ mod base_fee;
 pub mod builder;
 pub use builder::{ScrollPayloadBuilder, ScrollPayloadTransactions};
 
+pub mod config;
+pub use config::ScrollBuilderConfig;
+
 mod error;
 pub use error::ScrollPayloadBuilderError;
 


### PR DESCRIPTION
Adds configuration of the block gas limit in the `ScrollPayloadBuilder`.

WARNING ⚠️ : if not set using the `--builder.gaslimit`, the gas limit will default to the Ethereum Mainnet value (currently 36M).

Resolves #198 