### PR TITLE
feat: rpc addons trait

### DIFF
--- a/crates/e2e-test-utils/src/lib.rs
+++ b/crates/e2e-test-utils/src/lib.rs
@@ -5,9 +5,10 @@ use reth_chainspec::{ChainSpec, EthChainSpec};
 use reth_db::{test_utils::TempDatabase, DatabaseEnv};
 use reth_engine_local::LocalPayloadAttributesBuilder;
 use reth_network_api::test_utils::PeersHandleProvider;
+use reth_node_api::NodeAddOns;
 use reth_node_builder::{
     components::NodeComponentsBuilder,
-    rpc::{EngineValidatorAddOn, RethRpcAddOns},
+    rpc::{BeaconEngineHandleProvider, EngineValidatorAddOn, RethRpcAddOns, RpcHandleProvider},
     EngineNodeLauncher, FullNodeTypesAdapter, Node, NodeAdapter, NodeBuilder, NodeComponents,
     NodeConfig, NodeHandle, NodePrimitives, NodeTypes, NodeTypesWithDBAdapter,
     PayloadAttributesBuilder, PayloadTypes,
@@ -55,6 +56,14 @@ where
     N::AddOns: RethRpcAddOns<Adapter<N>> + EngineValidatorAddOn<Adapter<N>>,
     LocalPayloadAttributesBuilder<N::ChainSpec>:
         PayloadAttributesBuilder<<<N as NodeTypes>::Payload as PayloadTypes>::PayloadAttributes>,
+    <<N as Node<TmpNodeAdapter<N>>>::AddOns as NodeAddOns<Adapter<N>>>::Handle:
+        BeaconEngineHandleProvider<
+                Adapter<N>,
+                <<N as Node<TmpNodeAdapter<N>>>::AddOns as RethRpcAddOns<Adapter<N>>>::EthApi,
+            > + RpcHandleProvider<
+                Adapter<N>,
+                <<N as Node<TmpNodeAdapter<N>>>::AddOns as RethRpcAddOns<Adapter<N>>>::EthApi,
+            >,
 {
     let tasks = TaskManager::current();
     let exec = tasks.executor();
@@ -117,6 +126,14 @@ where
     N: NodeBuilderHelper,
     LocalPayloadAttributesBuilder<N::ChainSpec>:
         PayloadAttributesBuilder<<N::Payload as PayloadTypes>::PayloadAttributes>,
+    <<N as Node<TmpNodeAdapter<N>>>::AddOns as NodeAddOns<Adapter<N>>>::Handle:
+        BeaconEngineHandleProvider<
+                Adapter<N>,
+                <<N as Node<TmpNodeAdapter<N>>>::AddOns as RethRpcAddOns<Adapter<N>>>::EthApi,
+            > + RpcHandleProvider<
+                Adapter<N>,
+                <<N as Node<TmpNodeAdapter<N>>>::AddOns as RethRpcAddOns<Adapter<N>>>::EthApi,
+            >,
 {
     let tasks = TaskManager::current();
     let exec = tasks.executor();
@@ -234,6 +251,14 @@ where
         >,
     LocalPayloadAttributesBuilder<Self::ChainSpec>:
         PayloadAttributesBuilder<<Self::Payload as PayloadTypes>::PayloadAttributes>,
+    <<Self as Node<TmpNodeAdapter<Self>>>::AddOns as NodeAddOns<Adapter<Self>>>::Handle:
+        BeaconEngineHandleProvider<
+                Adapter<Self>,
+                <<Self as Node<TmpNodeAdapter<Self>>>::AddOns as RethRpcAddOns<Adapter<Self>>>::EthApi,
+            > + RpcHandleProvider<
+                Adapter<Self>,
+                <<Self as Node<TmpNodeAdapter<Self>>>::AddOns as RethRpcAddOns<Adapter<Self>>>::EthApi,
+            >,
 {
 }
 
@@ -269,5 +294,13 @@ where
         >,
     LocalPayloadAttributesBuilder<Self::ChainSpec>:
         PayloadAttributesBuilder<<Self::Payload as PayloadTypes>::PayloadAttributes>,
+    <<Self as Node<TmpNodeAdapter<Self>>>::AddOns as NodeAddOns<Adapter<Self>>>::Handle:
+        BeaconEngineHandleProvider<
+                Adapter<Self>,
+                <<Self as Node<TmpNodeAdapter<Self>>>::AddOns as RethRpcAddOns<Adapter<Self>>>::EthApi,
+            > + RpcHandleProvider<
+                Adapter<Self>,
+                <<Self as Node<TmpNodeAdapter<Self>>>::AddOns as RethRpcAddOns<Adapter<Self>>>::EthApi,
+            >,
 {
 }

--- a/crates/e2e-test-utils/src/lib.rs
+++ b/crates/e2e-test-utils/src/lib.rs
@@ -56,10 +56,7 @@ where
     N::AddOns: RethRpcAddOns<Adapter<N>> + EngineValidatorAddOn<Adapter<N>>,
     LocalPayloadAttributesBuilder<N::ChainSpec>:
         PayloadAttributesBuilder<<<N as NodeTypes>::Payload as PayloadTypes>::PayloadAttributes>,
-    <<N as Node<TmpNodeAdapter<N>>>::AddOns as NodeAddOns<Adapter<N>>>::Handle: RpcHandleProvider<
-        Adapter<N>,
-        <<N as Node<TmpNodeAdapter<N>>>::AddOns as RethRpcAddOns<Adapter<N>>>::EthApi,
-    >,
+    TmpNodeAddOnsHandle<N>: RpcHandleProvider<Adapter<N>, TmpNodeEthApi<N>>,
 {
     let tasks = TaskManager::current();
     let exec = tasks.executor();
@@ -122,10 +119,7 @@ where
     N: NodeBuilderHelper,
     LocalPayloadAttributesBuilder<N::ChainSpec>:
         PayloadAttributesBuilder<<N::Payload as PayloadTypes>::PayloadAttributes>,
-    <<N as Node<TmpNodeAdapter<N>>>::AddOns as NodeAddOns<Adapter<N>>>::Handle: RpcHandleProvider<
-        Adapter<N>,
-        <<N as Node<TmpNodeAdapter<N>>>::AddOns as RethRpcAddOns<Adapter<N>>>::EthApi,
-    >,
+    TmpNodeAddOnsHandle<N>: RpcHandleProvider<Adapter<N>, TmpNodeEthApi<N>>,
 {
     let tasks = TaskManager::current();
     let exec = tasks.executor();
@@ -206,6 +200,14 @@ pub type Adapter<N, Provider = BlockchainProvider<NodeTypesWithDBAdapter<N, TmpD
     >>::Components,
 >;
 
+/// Type alias for a `NodeHandle` for a `TmpNodeAdapter`.
+pub type TmpNodeAddOnsHandle<N> =
+    <<N as Node<TmpNodeAdapter<N>>>::AddOns as NodeAddOns<Adapter<N>>>::Handle;
+
+/// Type alias for the `EthApi` for a `TmpNodeAdapter`.
+pub type TmpNodeEthApi<N> =
+    <<N as Node<TmpNodeAdapter<N>>>::AddOns as RethRpcAddOns<Adapter<N>>>::EthApi;
+
 /// Type alias for a type of `NodeHelper`
 pub type NodeHelperType<N, Provider = BlockchainProvider<NodeTypesWithDBAdapter<N, TmpDB>>> =
     NodeTestContext<Adapter<N, Provider>, <N as Node<TmpNodeAdapter<N, Provider>>>::AddOns>;
@@ -243,11 +245,7 @@ where
         >,
     LocalPayloadAttributesBuilder<Self::ChainSpec>:
         PayloadAttributesBuilder<<Self::Payload as PayloadTypes>::PayloadAttributes>,
-    <<Self as Node<TmpNodeAdapter<Self>>>::AddOns as NodeAddOns<Adapter<Self>>>::Handle:
-        RpcHandleProvider<
-            Adapter<Self>,
-            <<Self as Node<TmpNodeAdapter<Self>>>::AddOns as RethRpcAddOns<Adapter<Self>>>::EthApi,
-        >,
+    TmpNodeAddOnsHandle<Self>: RpcHandleProvider<Adapter<Self>, TmpNodeEthApi<Self>>,
 {
 }
 
@@ -283,10 +281,6 @@ where
         >,
     LocalPayloadAttributesBuilder<Self::ChainSpec>:
         PayloadAttributesBuilder<<Self::Payload as PayloadTypes>::PayloadAttributes>,
-    <<Self as Node<TmpNodeAdapter<Self>>>::AddOns as NodeAddOns<Adapter<Self>>>::Handle:
-        RpcHandleProvider<
-            Adapter<Self>,
-            <<Self as Node<TmpNodeAdapter<Self>>>::AddOns as RethRpcAddOns<Adapter<Self>>>::EthApi,
-        >,
+    TmpNodeAddOnsHandle<Self>: RpcHandleProvider<Adapter<Self>, TmpNodeEthApi<Self>>,
 {
 }

--- a/crates/e2e-test-utils/src/lib.rs
+++ b/crates/e2e-test-utils/src/lib.rs
@@ -8,7 +8,7 @@ use reth_network_api::test_utils::PeersHandleProvider;
 use reth_node_api::NodeAddOns;
 use reth_node_builder::{
     components::NodeComponentsBuilder,
-    rpc::{BeaconEngineHandleProvider, EngineValidatorAddOn, RethRpcAddOns, RpcHandleProvider},
+    rpc::{EngineValidatorAddOn, RethRpcAddOns, RpcHandleProvider},
     EngineNodeLauncher, FullNodeTypesAdapter, Node, NodeAdapter, NodeBuilder, NodeComponents,
     NodeConfig, NodeHandle, NodePrimitives, NodeTypes, NodeTypesWithDBAdapter,
     PayloadAttributesBuilder, PayloadTypes,
@@ -56,14 +56,10 @@ where
     N::AddOns: RethRpcAddOns<Adapter<N>> + EngineValidatorAddOn<Adapter<N>>,
     LocalPayloadAttributesBuilder<N::ChainSpec>:
         PayloadAttributesBuilder<<<N as NodeTypes>::Payload as PayloadTypes>::PayloadAttributes>,
-    <<N as Node<TmpNodeAdapter<N>>>::AddOns as NodeAddOns<Adapter<N>>>::Handle:
-        BeaconEngineHandleProvider<
-                Adapter<N>,
-                <<N as Node<TmpNodeAdapter<N>>>::AddOns as RethRpcAddOns<Adapter<N>>>::EthApi,
-            > + RpcHandleProvider<
-                Adapter<N>,
-                <<N as Node<TmpNodeAdapter<N>>>::AddOns as RethRpcAddOns<Adapter<N>>>::EthApi,
-            >,
+    <<N as Node<TmpNodeAdapter<N>>>::AddOns as NodeAddOns<Adapter<N>>>::Handle: RpcHandleProvider<
+        Adapter<N>,
+        <<N as Node<TmpNodeAdapter<N>>>::AddOns as RethRpcAddOns<Adapter<N>>>::EthApi,
+    >,
 {
     let tasks = TaskManager::current();
     let exec = tasks.executor();
@@ -126,14 +122,10 @@ where
     N: NodeBuilderHelper,
     LocalPayloadAttributesBuilder<N::ChainSpec>:
         PayloadAttributesBuilder<<N::Payload as PayloadTypes>::PayloadAttributes>,
-    <<N as Node<TmpNodeAdapter<N>>>::AddOns as NodeAddOns<Adapter<N>>>::Handle:
-        BeaconEngineHandleProvider<
-                Adapter<N>,
-                <<N as Node<TmpNodeAdapter<N>>>::AddOns as RethRpcAddOns<Adapter<N>>>::EthApi,
-            > + RpcHandleProvider<
-                Adapter<N>,
-                <<N as Node<TmpNodeAdapter<N>>>::AddOns as RethRpcAddOns<Adapter<N>>>::EthApi,
-            >,
+    <<N as Node<TmpNodeAdapter<N>>>::AddOns as NodeAddOns<Adapter<N>>>::Handle: RpcHandleProvider<
+        Adapter<N>,
+        <<N as Node<TmpNodeAdapter<N>>>::AddOns as RethRpcAddOns<Adapter<N>>>::EthApi,
+    >,
 {
     let tasks = TaskManager::current();
     let exec = tasks.executor();
@@ -252,13 +244,10 @@ where
     LocalPayloadAttributesBuilder<Self::ChainSpec>:
         PayloadAttributesBuilder<<Self::Payload as PayloadTypes>::PayloadAttributes>,
     <<Self as Node<TmpNodeAdapter<Self>>>::AddOns as NodeAddOns<Adapter<Self>>>::Handle:
-        BeaconEngineHandleProvider<
-                Adapter<Self>,
-                <<Self as Node<TmpNodeAdapter<Self>>>::AddOns as RethRpcAddOns<Adapter<Self>>>::EthApi,
-            > + RpcHandleProvider<
-                Adapter<Self>,
-                <<Self as Node<TmpNodeAdapter<Self>>>::AddOns as RethRpcAddOns<Adapter<Self>>>::EthApi,
-            >,
+        RpcHandleProvider<
+            Adapter<Self>,
+            <<Self as Node<TmpNodeAdapter<Self>>>::AddOns as RethRpcAddOns<Adapter<Self>>>::EthApi,
+        >,
 {
 }
 
@@ -295,12 +284,9 @@ where
     LocalPayloadAttributesBuilder<Self::ChainSpec>:
         PayloadAttributesBuilder<<Self::Payload as PayloadTypes>::PayloadAttributes>,
     <<Self as Node<TmpNodeAdapter<Self>>>::AddOns as NodeAddOns<Adapter<Self>>>::Handle:
-        BeaconEngineHandleProvider<
-                Adapter<Self>,
-                <<Self as Node<TmpNodeAdapter<Self>>>::AddOns as RethRpcAddOns<Adapter<Self>>>::EthApi,
-            > + RpcHandleProvider<
-                Adapter<Self>,
-                <<Self as Node<TmpNodeAdapter<Self>>>::AddOns as RethRpcAddOns<Adapter<Self>>>::EthApi,
-            >,
+        RpcHandleProvider<
+            Adapter<Self>,
+            <<Self as Node<TmpNodeAdapter<Self>>>::AddOns as RethRpcAddOns<Adapter<Self>>>::EthApi,
+        >,
 {
 }

--- a/crates/e2e-test-utils/src/node.rs
+++ b/crates/e2e-test-utils/src/node.rs
@@ -14,7 +14,7 @@ use reth_node_api::{
     PrimitivesTy,
 };
 use reth_node_builder::{
-    rpc::{BeaconEngineHandleProvider, RethRpcAddOns, RpcHandleProvider},
+    rpc::{RethRpcAddOns, RpcHandleProvider},
     FullNode, NodeTypes,
 };
 use reth_node_core::primitives::SignedTransaction;
@@ -36,8 +36,7 @@ pub struct NodeTestContext<Node, AddOns>
 where
     Node: FullNodeComponents,
     AddOns: RethRpcAddOns<Node>,
-    AddOns::Handle: RpcHandleProvider<Node, <AddOns as RethRpcAddOns<Node>>::EthApi>
-        + BeaconEngineHandleProvider<Node, <AddOns as RethRpcAddOns<Node>>::EthApi>,
+    AddOns::Handle: RpcHandleProvider<Node, <AddOns as RethRpcAddOns<Node>>::EthApi>,
 {
     /// The core structure representing the full node.
     pub inner: FullNode<Node, AddOns>,
@@ -58,8 +57,7 @@ where
     Node::Types: NodeTypes<ChainSpec: EthereumHardforks, Payload = Payload>,
     Node::Network: PeersHandleProvider,
     AddOns: RethRpcAddOns<Node>,
-    AddOns::Handle: RpcHandleProvider<Node, <AddOns as RethRpcAddOns<Node>>::EthApi>
-        + BeaconEngineHandleProvider<Node, <AddOns as RethRpcAddOns<Node>>::EthApi>,
+    AddOns::Handle: RpcHandleProvider<Node, <AddOns as RethRpcAddOns<Node>>::EthApi>,
 {
     /// Creates a new test node
     pub async fn new(
@@ -265,7 +263,8 @@ where
     pub async fn update_forkchoice(&self, current_head: B256, new_head: B256) -> eyre::Result<()> {
         self.inner
             .add_ons_handle
-            .beacon_engine_handle()
+            .rpc_handle()
+            .beacon_engine_handle
             .fork_choice_updated(
                 ForkchoiceState {
                     head_block_hash: new_head,
@@ -290,7 +289,8 @@ where
         let block_hash = payload.block().hash();
         self.inner
             .add_ons_handle
-            .beacon_engine_handle()
+            .rpc_handle()
+            .beacon_engine_handle
             .new_payload(Payload::block_to_payload(payload.block().clone()))
             .await?;
 

--- a/crates/e2e-test-utils/src/node.rs
+++ b/crates/e2e-test-utils/src/node.rs
@@ -13,7 +13,10 @@ use reth_node_api::{
     Block, BlockBody, BlockTy, EngineApiMessageVersion, FullNodeComponents, PayloadTypes,
     PrimitivesTy,
 };
-use reth_node_builder::{rpc::RethRpcAddOns, FullNode, NodeTypes};
+use reth_node_builder::{
+    rpc::{BeaconEngineHandleProvider, RethRpcAddOns, RpcHandleProvider},
+    FullNode, NodeTypes,
+};
 use reth_node_core::primitives::SignedTransaction;
 use reth_payload_primitives::{BuiltPayload, PayloadBuilderAttributes};
 use reth_provider::{
@@ -33,6 +36,8 @@ pub struct NodeTestContext<Node, AddOns>
 where
     Node: FullNodeComponents,
     AddOns: RethRpcAddOns<Node>,
+    AddOns::Handle: RpcHandleProvider<Node, <AddOns as RethRpcAddOns<Node>>::EthApi>
+        + BeaconEngineHandleProvider<Node, <AddOns as RethRpcAddOns<Node>>::EthApi>,
 {
     /// The core structure representing the full node.
     pub inner: FullNode<Node, AddOns>,
@@ -53,6 +58,8 @@ where
     Node::Types: NodeTypes<ChainSpec: EthereumHardforks, Payload = Payload>,
     Node::Network: PeersHandleProvider,
     AddOns: RethRpcAddOns<Node>,
+    AddOns::Handle: RpcHandleProvider<Node, <AddOns as RethRpcAddOns<Node>>::EthApi>
+        + BeaconEngineHandleProvider<Node, <AddOns as RethRpcAddOns<Node>>::EthApi>,
 {
     /// Creates a new test node
     pub async fn new(
@@ -67,7 +74,7 @@ where
             )
             .await?,
             network: NetworkTestContext::new(node.network.clone()),
-            rpc: RpcTestContext { inner: node.add_ons_handle.rpc_registry },
+            rpc: RpcTestContext { inner: node.add_ons_handle.rpc_handle().rpc_registry.clone() },
             canonical_stream: node.provider.canonical_state_stream(),
         })
     }
@@ -258,7 +265,7 @@ where
     pub async fn update_forkchoice(&self, current_head: B256, new_head: B256) -> eyre::Result<()> {
         self.inner
             .add_ons_handle
-            .beacon_engine_handle
+            .beacon_engine_handle()
             .fork_choice_updated(
                 ForkchoiceState {
                     head_block_hash: new_head,
@@ -283,7 +290,7 @@ where
         let block_hash = payload.block().hash();
         self.inner
             .add_ons_handle
-            .beacon_engine_handle
+            .beacon_engine_handle()
             .new_payload(Payload::block_to_payload(payload.block().clone()))
             .await?;
 

--- a/crates/e2e-test-utils/src/testsuite/mod.rs
+++ b/crates/e2e-test-utils/src/testsuite/mod.rs
@@ -1,14 +1,18 @@
 //! Utilities for running e2e tests against a node or a network of nodes.
 
+use crate::testsuite::actions::{Action, ActionBox};
+
 use crate::{
-    testsuite::actions::{Action, ActionBox},
-    NodeBuilderHelper, PayloadAttributesBuilder,
+    BlockchainProvider, DatabaseEnv, FullNodeTypesAdapter, Node, NodeAdapter, NodeAddOns,
+    NodeBuilderHelper, NodeComponentsBuilder, NodeTypesWithDBAdapter, PayloadAttributesBuilder,
+    RethRpcAddOns, RpcHandleProvider, TempDatabase,
 };
 use alloy_primitives::B256;
 use eyre::Result;
 use jsonrpsee::http_client::{transport::HttpBackend, HttpClient};
 use reth_engine_local::LocalPayloadAttributesBuilder;
 use reth_node_api::{NodeTypes, PayloadTypes};
+use reth_node_builder::rpc::BeaconEngineHandleProvider;
 use reth_payload_builder::PayloadId;
 use reth_rpc_layer::AuthClientService;
 use setup::Setup;
@@ -16,6 +20,7 @@ use std::{collections::HashMap, marker::PhantomData};
 pub mod actions;
 pub mod setup;
 use alloy_rpc_types_engine::{ForkchoiceState, PayloadAttributes};
+use std::sync::Arc;
 
 #[cfg(test)]
 mod examples;
@@ -137,6 +142,188 @@ impl<I: 'static> TestBuilder<I> {
         N: NodeBuilderHelper,
         LocalPayloadAttributesBuilder<N::ChainSpec>: PayloadAttributesBuilder<
             <<N as NodeTypes>::Payload as PayloadTypes>::PayloadAttributes,
+        >,
+        <<N as Node<
+            FullNodeTypesAdapter<
+                N,
+                Arc<TempDatabase<DatabaseEnv>>,
+                BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
+            >,
+        >>::AddOns as NodeAddOns<
+            NodeAdapter<
+                FullNodeTypesAdapter<
+                    N,
+                    Arc<TempDatabase<DatabaseEnv>>,
+                    BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
+                >,
+                <<N as Node<
+                    FullNodeTypesAdapter<
+                        N,
+                        Arc<TempDatabase<DatabaseEnv>>,
+                        BlockchainProvider<
+                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
+                        >,
+                    >,
+                >>::ComponentsBuilder as NodeComponentsBuilder<
+                    FullNodeTypesAdapter<
+                        N,
+                        Arc<TempDatabase<DatabaseEnv>>,
+                        BlockchainProvider<
+                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
+                        >,
+                    >,
+                >>::Components,
+            >,
+        >>::Handle: RpcHandleProvider<
+            NodeAdapter<
+                FullNodeTypesAdapter<
+                    N,
+                    Arc<TempDatabase<DatabaseEnv>>,
+                    BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
+                >,
+                <<N as Node<
+                    FullNodeTypesAdapter<
+                        N,
+                        Arc<TempDatabase<DatabaseEnv>>,
+                        BlockchainProvider<
+                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
+                        >,
+                    >,
+                >>::ComponentsBuilder as NodeComponentsBuilder<
+                    FullNodeTypesAdapter<
+                        N,
+                        Arc<TempDatabase<DatabaseEnv>>,
+                        BlockchainProvider<
+                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
+                        >,
+                    >,
+                >>::Components,
+            >,
+            <<N as Node<
+                FullNodeTypesAdapter<
+                    N,
+                    Arc<TempDatabase<DatabaseEnv>>,
+                    BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
+                >,
+            >>::AddOns as RethRpcAddOns<
+                NodeAdapter<
+                    FullNodeTypesAdapter<
+                        N,
+                        Arc<TempDatabase<DatabaseEnv>>,
+                        BlockchainProvider<
+                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
+                        >,
+                    >,
+                    <<N as Node<
+                        FullNodeTypesAdapter<
+                            N,
+                            Arc<TempDatabase<DatabaseEnv>>,
+                            BlockchainProvider<
+                                NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
+                            >,
+                        >,
+                    >>::ComponentsBuilder as NodeComponentsBuilder<
+                        FullNodeTypesAdapter<
+                            N,
+                            Arc<TempDatabase<DatabaseEnv>>,
+                            BlockchainProvider<
+                                NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
+                            >,
+                        >,
+                    >>::Components,
+                >,
+            >>::EthApi,
+        >,
+        <<N as Node<
+            FullNodeTypesAdapter<
+                N,
+                Arc<TempDatabase<DatabaseEnv>>,
+                BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
+            >,
+        >>::AddOns as NodeAddOns<
+            NodeAdapter<
+                FullNodeTypesAdapter<
+                    N,
+                    Arc<TempDatabase<DatabaseEnv>>,
+                    BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
+                >,
+                <<N as Node<
+                    FullNodeTypesAdapter<
+                        N,
+                        Arc<TempDatabase<DatabaseEnv>>,
+                        BlockchainProvider<
+                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
+                        >,
+                    >,
+                >>::ComponentsBuilder as NodeComponentsBuilder<
+                    FullNodeTypesAdapter<
+                        N,
+                        Arc<TempDatabase<DatabaseEnv>>,
+                        BlockchainProvider<
+                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
+                        >,
+                    >,
+                >>::Components,
+            >,
+        >>::Handle: BeaconEngineHandleProvider<
+            NodeAdapter<
+                FullNodeTypesAdapter<
+                    N,
+                    Arc<TempDatabase<DatabaseEnv>>,
+                    BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
+                >,
+                <<N as Node<
+                    FullNodeTypesAdapter<
+                        N,
+                        Arc<TempDatabase<DatabaseEnv>>,
+                        BlockchainProvider<
+                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
+                        >,
+                    >,
+                >>::ComponentsBuilder as NodeComponentsBuilder<
+                    FullNodeTypesAdapter<
+                        N,
+                        Arc<TempDatabase<DatabaseEnv>>,
+                        BlockchainProvider<
+                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
+                        >,
+                    >,
+                >>::Components,
+            >,
+            <<N as Node<
+                FullNodeTypesAdapter<
+                    N,
+                    Arc<TempDatabase<DatabaseEnv>>,
+                    BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
+                >,
+            >>::AddOns as RethRpcAddOns<
+                NodeAdapter<
+                    FullNodeTypesAdapter<
+                        N,
+                        Arc<TempDatabase<DatabaseEnv>>,
+                        BlockchainProvider<
+                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
+                        >,
+                    >,
+                    <<N as Node<
+                        FullNodeTypesAdapter<
+                            N,
+                            Arc<TempDatabase<DatabaseEnv>>,
+                            BlockchainProvider<
+                                NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
+                            >,
+                        >,
+                    >>::ComponentsBuilder as NodeComponentsBuilder<
+                        FullNodeTypesAdapter<
+                            N,
+                            Arc<TempDatabase<DatabaseEnv>>,
+                            BlockchainProvider<
+                                NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
+                            >,
+                        >,
+                    >>::Components,
+                >,
+            >>::EthApi,
         >,
     {
         let mut setup = self.setup.take();

--- a/crates/e2e-test-utils/src/testsuite/mod.rs
+++ b/crates/e2e-test-utils/src/testsuite/mod.rs
@@ -1,10 +1,9 @@
 //! Utilities for running e2e tests against a node or a network of nodes.
 
-use crate::testsuite::actions::{Action, ActionBox};
-
 use crate::{
-    Adapter, Node, NodeAdapter, NodeAddOns, NodeBuilderHelper, NodeComponentsBuilder,
-    PayloadAttributesBuilder, RethRpcAddOns, RpcHandleProvider, TmpNodeAdapter,
+    testsuite::actions::{Action, ActionBox},
+    Adapter, NodeBuilderHelper, PayloadAttributesBuilder, RpcHandleProvider, TmpNodeAddOnsHandle,
+    TmpNodeEthApi,
 };
 use alloy_primitives::B256;
 use eyre::Result;
@@ -140,16 +139,7 @@ impl<I: 'static> TestBuilder<I> {
         LocalPayloadAttributesBuilder<N::ChainSpec>: PayloadAttributesBuilder<
             <<N as NodeTypes>::Payload as PayloadTypes>::PayloadAttributes,
         >,
-        <<N as Node<TmpNodeAdapter<N>>>::AddOns as NodeAddOns<Adapter<N>>>::Handle:
-            RpcHandleProvider<
-                NodeAdapter<
-                    TmpNodeAdapter<N>,
-                    <<N as Node<TmpNodeAdapter<N>>>::ComponentsBuilder as NodeComponentsBuilder<
-                        TmpNodeAdapter<N>,
-                    >>::Components,
-                >,
-                <<N as Node<TmpNodeAdapter<N>>>::AddOns as RethRpcAddOns<Adapter<N>>>::EthApi,
-            >,
+        TmpNodeAddOnsHandle<N>: RpcHandleProvider<Adapter<N>, TmpNodeEthApi<N>>,
     {
         let mut setup = self.setup.take();
 

--- a/crates/e2e-test-utils/src/testsuite/mod.rs
+++ b/crates/e2e-test-utils/src/testsuite/mod.rs
@@ -3,16 +3,14 @@
 use crate::testsuite::actions::{Action, ActionBox};
 
 use crate::{
-    BlockchainProvider, DatabaseEnv, FullNodeTypesAdapter, Node, NodeAdapter, NodeAddOns,
-    NodeBuilderHelper, NodeComponentsBuilder, NodeTypesWithDBAdapter, PayloadAttributesBuilder,
-    RethRpcAddOns, RpcHandleProvider, TempDatabase,
+    Adapter, Node, NodeAdapter, NodeAddOns, NodeBuilderHelper, NodeComponentsBuilder,
+    PayloadAttributesBuilder, RethRpcAddOns, RpcHandleProvider, TmpNodeAdapter,
 };
 use alloy_primitives::B256;
 use eyre::Result;
 use jsonrpsee::http_client::{transport::HttpBackend, HttpClient};
 use reth_engine_local::LocalPayloadAttributesBuilder;
 use reth_node_api::{NodeTypes, PayloadTypes};
-use reth_node_builder::rpc::BeaconEngineHandleProvider;
 use reth_payload_builder::PayloadId;
 use reth_rpc_layer::AuthClientService;
 use setup::Setup;
@@ -20,7 +18,6 @@ use std::{collections::HashMap, marker::PhantomData};
 pub mod actions;
 pub mod setup;
 use alloy_rpc_types_engine::{ForkchoiceState, PayloadAttributes};
-use std::sync::Arc;
 
 #[cfg(test)]
 mod examples;
@@ -143,188 +140,16 @@ impl<I: 'static> TestBuilder<I> {
         LocalPayloadAttributesBuilder<N::ChainSpec>: PayloadAttributesBuilder<
             <<N as NodeTypes>::Payload as PayloadTypes>::PayloadAttributes,
         >,
-        <<N as Node<
-            FullNodeTypesAdapter<
-                N,
-                Arc<TempDatabase<DatabaseEnv>>,
-                BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
-            >,
-        >>::AddOns as NodeAddOns<
-            NodeAdapter<
-                FullNodeTypesAdapter<
-                    N,
-                    Arc<TempDatabase<DatabaseEnv>>,
-                    BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
-                >,
-                <<N as Node<
-                    FullNodeTypesAdapter<
-                        N,
-                        Arc<TempDatabase<DatabaseEnv>>,
-                        BlockchainProvider<
-                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
-                        >,
-                    >,
-                >>::ComponentsBuilder as NodeComponentsBuilder<
-                    FullNodeTypesAdapter<
-                        N,
-                        Arc<TempDatabase<DatabaseEnv>>,
-                        BlockchainProvider<
-                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
-                        >,
-                    >,
-                >>::Components,
-            >,
-        >>::Handle: RpcHandleProvider<
-            NodeAdapter<
-                FullNodeTypesAdapter<
-                    N,
-                    Arc<TempDatabase<DatabaseEnv>>,
-                    BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
-                >,
-                <<N as Node<
-                    FullNodeTypesAdapter<
-                        N,
-                        Arc<TempDatabase<DatabaseEnv>>,
-                        BlockchainProvider<
-                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
-                        >,
-                    >,
-                >>::ComponentsBuilder as NodeComponentsBuilder<
-                    FullNodeTypesAdapter<
-                        N,
-                        Arc<TempDatabase<DatabaseEnv>>,
-                        BlockchainProvider<
-                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
-                        >,
-                    >,
-                >>::Components,
-            >,
-            <<N as Node<
-                FullNodeTypesAdapter<
-                    N,
-                    Arc<TempDatabase<DatabaseEnv>>,
-                    BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
-                >,
-            >>::AddOns as RethRpcAddOns<
+        <<N as Node<TmpNodeAdapter<N>>>::AddOns as NodeAddOns<Adapter<N>>>::Handle:
+            RpcHandleProvider<
                 NodeAdapter<
-                    FullNodeTypesAdapter<
-                        N,
-                        Arc<TempDatabase<DatabaseEnv>>,
-                        BlockchainProvider<
-                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
-                        >,
-                    >,
-                    <<N as Node<
-                        FullNodeTypesAdapter<
-                            N,
-                            Arc<TempDatabase<DatabaseEnv>>,
-                            BlockchainProvider<
-                                NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
-                            >,
-                        >,
-                    >>::ComponentsBuilder as NodeComponentsBuilder<
-                        FullNodeTypesAdapter<
-                            N,
-                            Arc<TempDatabase<DatabaseEnv>>,
-                            BlockchainProvider<
-                                NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
-                            >,
-                        >,
+                    TmpNodeAdapter<N>,
+                    <<N as Node<TmpNodeAdapter<N>>>::ComponentsBuilder as NodeComponentsBuilder<
+                        TmpNodeAdapter<N>,
                     >>::Components,
                 >,
-            >>::EthApi,
-        >,
-        <<N as Node<
-            FullNodeTypesAdapter<
-                N,
-                Arc<TempDatabase<DatabaseEnv>>,
-                BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
+                <<N as Node<TmpNodeAdapter<N>>>::AddOns as RethRpcAddOns<Adapter<N>>>::EthApi,
             >,
-        >>::AddOns as NodeAddOns<
-            NodeAdapter<
-                FullNodeTypesAdapter<
-                    N,
-                    Arc<TempDatabase<DatabaseEnv>>,
-                    BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
-                >,
-                <<N as Node<
-                    FullNodeTypesAdapter<
-                        N,
-                        Arc<TempDatabase<DatabaseEnv>>,
-                        BlockchainProvider<
-                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
-                        >,
-                    >,
-                >>::ComponentsBuilder as NodeComponentsBuilder<
-                    FullNodeTypesAdapter<
-                        N,
-                        Arc<TempDatabase<DatabaseEnv>>,
-                        BlockchainProvider<
-                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
-                        >,
-                    >,
-                >>::Components,
-            >,
-        >>::Handle: BeaconEngineHandleProvider<
-            NodeAdapter<
-                FullNodeTypesAdapter<
-                    N,
-                    Arc<TempDatabase<DatabaseEnv>>,
-                    BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
-                >,
-                <<N as Node<
-                    FullNodeTypesAdapter<
-                        N,
-                        Arc<TempDatabase<DatabaseEnv>>,
-                        BlockchainProvider<
-                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
-                        >,
-                    >,
-                >>::ComponentsBuilder as NodeComponentsBuilder<
-                    FullNodeTypesAdapter<
-                        N,
-                        Arc<TempDatabase<DatabaseEnv>>,
-                        BlockchainProvider<
-                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
-                        >,
-                    >,
-                >>::Components,
-            >,
-            <<N as Node<
-                FullNodeTypesAdapter<
-                    N,
-                    Arc<TempDatabase<DatabaseEnv>>,
-                    BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
-                >,
-            >>::AddOns as RethRpcAddOns<
-                NodeAdapter<
-                    FullNodeTypesAdapter<
-                        N,
-                        Arc<TempDatabase<DatabaseEnv>>,
-                        BlockchainProvider<
-                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
-                        >,
-                    >,
-                    <<N as Node<
-                        FullNodeTypesAdapter<
-                            N,
-                            Arc<TempDatabase<DatabaseEnv>>,
-                            BlockchainProvider<
-                                NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
-                            >,
-                        >,
-                    >>::ComponentsBuilder as NodeComponentsBuilder<
-                        FullNodeTypesAdapter<
-                            N,
-                            Arc<TempDatabase<DatabaseEnv>>,
-                            BlockchainProvider<
-                                NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
-                            >,
-                        >,
-                    >>::Components,
-                >,
-            >>::EthApi,
-        >,
     {
         let mut setup = self.setup.take();
 

--- a/crates/e2e-test-utils/src/testsuite/setup.rs
+++ b/crates/e2e-test-utils/src/testsuite/setup.rs
@@ -1,9 +1,8 @@
 //! Test setup utilities for configuring the initial state.
 
 use crate::{
-    setup_engine, testsuite::Environment, Adapter, Node, NodeAdapter, NodeAddOns,
-    NodeBuilderHelper, NodeComponentsBuilder, PayloadAttributesBuilder, RethRpcAddOns,
-    RpcHandleProvider, TmpNodeAdapter,
+    setup_engine, testsuite::Environment, Adapter, NodeBuilderHelper, PayloadAttributesBuilder,
+    RpcHandleProvider, TmpNodeAddOnsHandle, TmpNodeEthApi,
 };
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::B256;
@@ -125,16 +124,7 @@ impl<I> Setup<I> {
         LocalPayloadAttributesBuilder<N::ChainSpec>: PayloadAttributesBuilder<
             <<N as NodeTypes>::Payload as PayloadTypes>::PayloadAttributes,
         >,
-        <<N as Node<TmpNodeAdapter<N>>>::AddOns as NodeAddOns<Adapter<N>>>::Handle:
-            RpcHandleProvider<
-                NodeAdapter<
-                    TmpNodeAdapter<N>,
-                    <<N as Node<TmpNodeAdapter<N>>>::ComponentsBuilder as NodeComponentsBuilder<
-                        TmpNodeAdapter<N>,
-                    >>::Components,
-                >,
-                <<N as Node<TmpNodeAdapter<N>>>::AddOns as RethRpcAddOns<Adapter<N>>>::EthApi,
-            >,
+        TmpNodeAddOnsHandle<N>: RpcHandleProvider<Adapter<N>, TmpNodeEthApi<N>>,
     {
         let chain_spec =
             self.chain_spec.clone().ok_or_else(|| eyre!("Chain specification is required"))?;

--- a/crates/e2e-test-utils/src/testsuite/setup.rs
+++ b/crates/e2e-test-utils/src/testsuite/setup.rs
@@ -1,10 +1,9 @@
 //! Test setup utilities for configuring the initial state.
 
 use crate::{
-    setup_engine, testsuite::Environment, BeaconEngineHandleProvider, BlockchainProvider,
-    DatabaseEnv, FullNodeTypesAdapter, Node, NodeAdapter, NodeAddOns, NodeBuilderHelper,
-    NodeComponentsBuilder, NodeTypesWithDBAdapter, PayloadAttributesBuilder, RethRpcAddOns,
-    RpcHandleProvider, TempDatabase,
+    setup_engine, testsuite::Environment, Adapter, Node, NodeAdapter, NodeAddOns,
+    NodeBuilderHelper, NodeComponentsBuilder, PayloadAttributesBuilder, RethRpcAddOns,
+    RpcHandleProvider, TmpNodeAdapter,
 };
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::B256;
@@ -126,188 +125,16 @@ impl<I> Setup<I> {
         LocalPayloadAttributesBuilder<N::ChainSpec>: PayloadAttributesBuilder<
             <<N as NodeTypes>::Payload as PayloadTypes>::PayloadAttributes,
         >,
-        <<N as Node<
-            FullNodeTypesAdapter<
-                N,
-                Arc<TempDatabase<DatabaseEnv>>,
-                BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
-            >,
-        >>::AddOns as NodeAddOns<
-            NodeAdapter<
-                FullNodeTypesAdapter<
-                    N,
-                    Arc<TempDatabase<DatabaseEnv>>,
-                    BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
-                >,
-                <<N as Node<
-                    FullNodeTypesAdapter<
-                        N,
-                        Arc<TempDatabase<DatabaseEnv>>,
-                        BlockchainProvider<
-                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
-                        >,
-                    >,
-                >>::ComponentsBuilder as NodeComponentsBuilder<
-                    FullNodeTypesAdapter<
-                        N,
-                        Arc<TempDatabase<DatabaseEnv>>,
-                        BlockchainProvider<
-                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
-                        >,
-                    >,
-                >>::Components,
-            >,
-        >>::Handle: RpcHandleProvider<
-            NodeAdapter<
-                FullNodeTypesAdapter<
-                    N,
-                    Arc<TempDatabase<DatabaseEnv>>,
-                    BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
-                >,
-                <<N as Node<
-                    FullNodeTypesAdapter<
-                        N,
-                        Arc<TempDatabase<DatabaseEnv>>,
-                        BlockchainProvider<
-                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
-                        >,
-                    >,
-                >>::ComponentsBuilder as NodeComponentsBuilder<
-                    FullNodeTypesAdapter<
-                        N,
-                        Arc<TempDatabase<DatabaseEnv>>,
-                        BlockchainProvider<
-                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
-                        >,
-                    >,
-                >>::Components,
-            >,
-            <<N as Node<
-                FullNodeTypesAdapter<
-                    N,
-                    Arc<TempDatabase<DatabaseEnv>>,
-                    BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
-                >,
-            >>::AddOns as RethRpcAddOns<
+        <<N as Node<TmpNodeAdapter<N>>>::AddOns as NodeAddOns<Adapter<N>>>::Handle:
+            RpcHandleProvider<
                 NodeAdapter<
-                    FullNodeTypesAdapter<
-                        N,
-                        Arc<TempDatabase<DatabaseEnv>>,
-                        BlockchainProvider<
-                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
-                        >,
-                    >,
-                    <<N as Node<
-                        FullNodeTypesAdapter<
-                            N,
-                            Arc<TempDatabase<DatabaseEnv>>,
-                            BlockchainProvider<
-                                NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
-                            >,
-                        >,
-                    >>::ComponentsBuilder as NodeComponentsBuilder<
-                        FullNodeTypesAdapter<
-                            N,
-                            Arc<TempDatabase<DatabaseEnv>>,
-                            BlockchainProvider<
-                                NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
-                            >,
-                        >,
+                    TmpNodeAdapter<N>,
+                    <<N as Node<TmpNodeAdapter<N>>>::ComponentsBuilder as NodeComponentsBuilder<
+                        TmpNodeAdapter<N>,
                     >>::Components,
                 >,
-            >>::EthApi,
-        >,
-        <<N as Node<
-            FullNodeTypesAdapter<
-                N,
-                Arc<TempDatabase<DatabaseEnv>>,
-                BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
+                <<N as Node<TmpNodeAdapter<N>>>::AddOns as RethRpcAddOns<Adapter<N>>>::EthApi,
             >,
-        >>::AddOns as NodeAddOns<
-            NodeAdapter<
-                FullNodeTypesAdapter<
-                    N,
-                    Arc<TempDatabase<DatabaseEnv>>,
-                    BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
-                >,
-                <<N as Node<
-                    FullNodeTypesAdapter<
-                        N,
-                        Arc<TempDatabase<DatabaseEnv>>,
-                        BlockchainProvider<
-                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
-                        >,
-                    >,
-                >>::ComponentsBuilder as NodeComponentsBuilder<
-                    FullNodeTypesAdapter<
-                        N,
-                        Arc<TempDatabase<DatabaseEnv>>,
-                        BlockchainProvider<
-                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
-                        >,
-                    >,
-                >>::Components,
-            >,
-        >>::Handle: BeaconEngineHandleProvider<
-            NodeAdapter<
-                FullNodeTypesAdapter<
-                    N,
-                    Arc<TempDatabase<DatabaseEnv>>,
-                    BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
-                >,
-                <<N as Node<
-                    FullNodeTypesAdapter<
-                        N,
-                        Arc<TempDatabase<DatabaseEnv>>,
-                        BlockchainProvider<
-                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
-                        >,
-                    >,
-                >>::ComponentsBuilder as NodeComponentsBuilder<
-                    FullNodeTypesAdapter<
-                        N,
-                        Arc<TempDatabase<DatabaseEnv>>,
-                        BlockchainProvider<
-                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
-                        >,
-                    >,
-                >>::Components,
-            >,
-            <<N as Node<
-                FullNodeTypesAdapter<
-                    N,
-                    Arc<TempDatabase<DatabaseEnv>>,
-                    BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
-                >,
-            >>::AddOns as RethRpcAddOns<
-                NodeAdapter<
-                    FullNodeTypesAdapter<
-                        N,
-                        Arc<TempDatabase<DatabaseEnv>>,
-                        BlockchainProvider<
-                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
-                        >,
-                    >,
-                    <<N as Node<
-                        FullNodeTypesAdapter<
-                            N,
-                            Arc<TempDatabase<DatabaseEnv>>,
-                            BlockchainProvider<
-                                NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
-                            >,
-                        >,
-                    >>::ComponentsBuilder as NodeComponentsBuilder<
-                        FullNodeTypesAdapter<
-                            N,
-                            Arc<TempDatabase<DatabaseEnv>>,
-                            BlockchainProvider<
-                                NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
-                            >,
-                        >,
-                    >>::Components,
-                >,
-            >>::EthApi,
-        >,
     {
         let chain_spec =
             self.chain_spec.clone().ok_or_else(|| eyre!("Chain specification is required"))?;

--- a/crates/e2e-test-utils/src/testsuite/setup.rs
+++ b/crates/e2e-test-utils/src/testsuite/setup.rs
@@ -1,6 +1,11 @@
 //! Test setup utilities for configuring the initial state.
 
-use crate::{setup_engine, testsuite::Environment, NodeBuilderHelper, PayloadAttributesBuilder};
+use crate::{
+    setup_engine, testsuite::Environment, BeaconEngineHandleProvider, BlockchainProvider,
+    DatabaseEnv, FullNodeTypesAdapter, Node, NodeAdapter, NodeAddOns, NodeBuilderHelper,
+    NodeComponentsBuilder, NodeTypesWithDBAdapter, PayloadAttributesBuilder, RethRpcAddOns,
+    RpcHandleProvider, TempDatabase,
+};
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::B256;
 use alloy_rpc_types_engine::PayloadAttributes;
@@ -120,6 +125,188 @@ impl<I> Setup<I> {
         N: NodeBuilderHelper,
         LocalPayloadAttributesBuilder<N::ChainSpec>: PayloadAttributesBuilder<
             <<N as NodeTypes>::Payload as PayloadTypes>::PayloadAttributes,
+        >,
+        <<N as Node<
+            FullNodeTypesAdapter<
+                N,
+                Arc<TempDatabase<DatabaseEnv>>,
+                BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
+            >,
+        >>::AddOns as NodeAddOns<
+            NodeAdapter<
+                FullNodeTypesAdapter<
+                    N,
+                    Arc<TempDatabase<DatabaseEnv>>,
+                    BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
+                >,
+                <<N as Node<
+                    FullNodeTypesAdapter<
+                        N,
+                        Arc<TempDatabase<DatabaseEnv>>,
+                        BlockchainProvider<
+                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
+                        >,
+                    >,
+                >>::ComponentsBuilder as NodeComponentsBuilder<
+                    FullNodeTypesAdapter<
+                        N,
+                        Arc<TempDatabase<DatabaseEnv>>,
+                        BlockchainProvider<
+                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
+                        >,
+                    >,
+                >>::Components,
+            >,
+        >>::Handle: RpcHandleProvider<
+            NodeAdapter<
+                FullNodeTypesAdapter<
+                    N,
+                    Arc<TempDatabase<DatabaseEnv>>,
+                    BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
+                >,
+                <<N as Node<
+                    FullNodeTypesAdapter<
+                        N,
+                        Arc<TempDatabase<DatabaseEnv>>,
+                        BlockchainProvider<
+                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
+                        >,
+                    >,
+                >>::ComponentsBuilder as NodeComponentsBuilder<
+                    FullNodeTypesAdapter<
+                        N,
+                        Arc<TempDatabase<DatabaseEnv>>,
+                        BlockchainProvider<
+                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
+                        >,
+                    >,
+                >>::Components,
+            >,
+            <<N as Node<
+                FullNodeTypesAdapter<
+                    N,
+                    Arc<TempDatabase<DatabaseEnv>>,
+                    BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
+                >,
+            >>::AddOns as RethRpcAddOns<
+                NodeAdapter<
+                    FullNodeTypesAdapter<
+                        N,
+                        Arc<TempDatabase<DatabaseEnv>>,
+                        BlockchainProvider<
+                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
+                        >,
+                    >,
+                    <<N as Node<
+                        FullNodeTypesAdapter<
+                            N,
+                            Arc<TempDatabase<DatabaseEnv>>,
+                            BlockchainProvider<
+                                NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
+                            >,
+                        >,
+                    >>::ComponentsBuilder as NodeComponentsBuilder<
+                        FullNodeTypesAdapter<
+                            N,
+                            Arc<TempDatabase<DatabaseEnv>>,
+                            BlockchainProvider<
+                                NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
+                            >,
+                        >,
+                    >>::Components,
+                >,
+            >>::EthApi,
+        >,
+        <<N as Node<
+            FullNodeTypesAdapter<
+                N,
+                Arc<TempDatabase<DatabaseEnv>>,
+                BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
+            >,
+        >>::AddOns as NodeAddOns<
+            NodeAdapter<
+                FullNodeTypesAdapter<
+                    N,
+                    Arc<TempDatabase<DatabaseEnv>>,
+                    BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
+                >,
+                <<N as Node<
+                    FullNodeTypesAdapter<
+                        N,
+                        Arc<TempDatabase<DatabaseEnv>>,
+                        BlockchainProvider<
+                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
+                        >,
+                    >,
+                >>::ComponentsBuilder as NodeComponentsBuilder<
+                    FullNodeTypesAdapter<
+                        N,
+                        Arc<TempDatabase<DatabaseEnv>>,
+                        BlockchainProvider<
+                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
+                        >,
+                    >,
+                >>::Components,
+            >,
+        >>::Handle: BeaconEngineHandleProvider<
+            NodeAdapter<
+                FullNodeTypesAdapter<
+                    N,
+                    Arc<TempDatabase<DatabaseEnv>>,
+                    BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
+                >,
+                <<N as Node<
+                    FullNodeTypesAdapter<
+                        N,
+                        Arc<TempDatabase<DatabaseEnv>>,
+                        BlockchainProvider<
+                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
+                        >,
+                    >,
+                >>::ComponentsBuilder as NodeComponentsBuilder<
+                    FullNodeTypesAdapter<
+                        N,
+                        Arc<TempDatabase<DatabaseEnv>>,
+                        BlockchainProvider<
+                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
+                        >,
+                    >,
+                >>::Components,
+            >,
+            <<N as Node<
+                FullNodeTypesAdapter<
+                    N,
+                    Arc<TempDatabase<DatabaseEnv>>,
+                    BlockchainProvider<NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>>,
+                >,
+            >>::AddOns as RethRpcAddOns<
+                NodeAdapter<
+                    FullNodeTypesAdapter<
+                        N,
+                        Arc<TempDatabase<DatabaseEnv>>,
+                        BlockchainProvider<
+                            NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
+                        >,
+                    >,
+                    <<N as Node<
+                        FullNodeTypesAdapter<
+                            N,
+                            Arc<TempDatabase<DatabaseEnv>>,
+                            BlockchainProvider<
+                                NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
+                            >,
+                        >,
+                    >>::ComponentsBuilder as NodeComponentsBuilder<
+                        FullNodeTypesAdapter<
+                            N,
+                            Arc<TempDatabase<DatabaseEnv>>,
+                            BlockchainProvider<
+                                NodeTypesWithDBAdapter<N, Arc<TempDatabase<DatabaseEnv>>>,
+                            >,
+                        >,
+                    >>::Components,
+                >,
+            >>::EthApi,
         >,
     {
         let chain_spec =

--- a/crates/ethereum/node/tests/e2e/dev.rs
+++ b/crates/ethereum/node/tests/e2e/dev.rs
@@ -3,9 +3,10 @@ use alloy_genesis::Genesis;
 use alloy_primitives::{b256, hex};
 use futures::StreamExt;
 use reth_chainspec::ChainSpec;
-use reth_node_api::{BlockBody, FullNodeComponents, FullNodePrimitives, NodeTypes};
+use reth_node_api::{BlockBody, FullNodeComponents, FullNodePrimitives, NodeAddOns, NodeTypes};
 use reth_node_builder::{
-    rpc::RethRpcAddOns, EngineNodeLauncher, FullNode, NodeBuilder, NodeConfig, NodeHandle,
+    rpc::{RethRpcAddOns, RpcHandleProvider},
+    EngineNodeLauncher, FullNode, NodeBuilder, NodeConfig, NodeHandle,
 };
 use reth_node_core::args::DevArgs;
 use reth_node_ethereum::{node::EthereumAddOns, EthereumNode};
@@ -48,6 +49,7 @@ where
     N: FullNodeComponents<Provider: CanonStateSubscriptions>,
     AddOns: RethRpcAddOns<N, EthApi: EthTransactions>,
     N::Types: NodeTypes<Primitives: FullNodePrimitives>,
+    <AddOns as NodeAddOns<N>>::Handle: RpcHandleProvider<N, <AddOns as RethRpcAddOns<N>>::EthApi>,
 {
     let mut notifications = node.provider.canonical_state_stream();
 
@@ -56,7 +58,7 @@ where
         "02f876820a28808477359400847735940082520894ab0840c0e43688012c1adb0f5e3fc665188f83d28a029d394a5d630544000080c080a0a044076b7e67b5deecc63f61a8d7913fab86ca365b344b5759d1fe3563b4c39ea019eab979dd000da04dfc72bb0377c092d30fd9e1cab5ae487de49586cc8b0090"
     );
 
-    let eth_api = node.rpc_registry.eth_api();
+    let eth_api = node.rpc_handle().rpc_registry.eth_api();
 
     let hash = eth_api.send_raw_transaction(raw_tx.into()).await.unwrap();
 

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -50,6 +50,14 @@ pub use states::*;
 pub type RethFullAdapter<DB, Types> =
     FullNodeTypesAdapter<Types, DB, BlockchainProvider<NodeTypesWithDBAdapter<Types, DB>>>;
 
+/// A full node adapter for a reth node with the builtin provider type
+type FullNodeAdapter<N, DB> = NodeAdapter<
+    RethFullAdapter<DB, N>,
+    <<N as Node<RethFullAdapter<DB, N>>>::ComponentsBuilder as NodeComponentsBuilder<
+        RethFullAdapter<DB, N>,
+    >>::Components,
+>;
+
 #[expect(clippy::doc_markdown)]
 #[cfg_attr(doc, aquamarine::aquamarine)]
 /// Declaratively construct a node.
@@ -350,36 +358,10 @@ where
     >
     where
         N: Node<RethFullAdapter<DB, N>, ChainSpec = ChainSpec> + NodeTypesForProvider,
-        N::AddOns: RethRpcAddOns<
-            NodeAdapter<
-                RethFullAdapter<DB, N>,
-                <N::ComponentsBuilder as NodeComponentsBuilder<RethFullAdapter<DB, N>>>::Components,
-            >,
-        >,
-        <<N as Node<RethFullAdapter<DB, N>>>::AddOns as reth_node_api::NodeAddOns<
-            NodeAdapter<
-                RethFullAdapter<DB, N>,
-                <<N as Node<RethFullAdapter<DB, N>>>::ComponentsBuilder as NodeComponentsBuilder<
-                    RethFullAdapter<DB, N>,
-                >>::Components,
-            >,
-        >>::Handle: RpcHandleProvider<
-            NodeAdapter<
-                RethFullAdapter<DB, N>,
-                <<N as Node<RethFullAdapter<DB, N>>>::ComponentsBuilder as NodeComponentsBuilder<
-                    RethFullAdapter<DB, N>,
-                >>::Components,
-            >,
-            <<N as Node<RethFullAdapter<DB, N>>>::AddOns as RethRpcAddOns<
-                NodeAdapter<
-                    RethFullAdapter<DB, N>,
-                    <<N as Node<
-                        RethFullAdapter<DB, N>,
-                    >>::ComponentsBuilder as NodeComponentsBuilder<
-                        RethFullAdapter<DB, N>,
-                    >>::Components,
-                >,
-            >>::EthApi,
+        N::AddOns: RethRpcAddOns<FullNodeAdapter<N, DB>>,
+        <N::AddOns as NodeAddOns<FullNodeAdapter<N, DB>>>::Handle: RpcHandleProvider<
+            FullNodeAdapter<N, DB>,
+            <N::AddOns as RethRpcAddOns<FullNodeAdapter<N, DB>>>::EthApi,
         >,
         N::Primitives: FullNodePrimitives,
         EngineNodeLauncher: LaunchNode<
@@ -432,7 +414,7 @@ where
     T: FullNodeTypes,
     CB: NodeComponentsBuilder<T>,
     AO: RethRpcAddOns<NodeAdapter<T, CB::Components>>,
-    <AO as reth_node_api::NodeAddOns<
+    <AO as NodeAddOns<
         NodeAdapter<T, <CB as NodeComponentsBuilder<T>>::Components>,
     >>::Handle: RpcHandleProvider<
         NodeAdapter<T, <CB as NodeComponentsBuilder<T>>::Components>,

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     common::WithConfigs,
     components::NodeComponentsBuilder,
     node::FullNode,
-    rpc::{RethRpcAddOns, RethRpcServerHandles, RpcContext},
+    rpc::{RethRpcAddOns, RethRpcServerHandles, RpcContext, RpcHandleProvider},
     BlockReaderFor, DebugNode, DebugNodeLauncher, EngineNodeLauncher, LaunchNode, Node,
 };
 use alloy_eips::eip4844::env_settings::EnvKzgSettings;
@@ -356,6 +356,47 @@ where
                 <N::ComponentsBuilder as NodeComponentsBuilder<RethFullAdapter<DB, N>>>::Components,
             >,
         >,
+        <<N as Node<
+            FullNodeTypesAdapter<N, DB, BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>>,
+        >>::AddOns as reth_node_api::NodeAddOns<
+            NodeAdapter<
+                FullNodeTypesAdapter<N, DB, BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>>,
+                <<N as Node<
+                    FullNodeTypesAdapter<N, DB, BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>>,
+                >>::ComponentsBuilder as NodeComponentsBuilder<
+                    FullNodeTypesAdapter<N, DB, BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>>,
+                >>::Components,
+            >,
+        >>::Handle: RpcHandleProvider<
+            NodeAdapter<
+                FullNodeTypesAdapter<N, DB, BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>>,
+                <<N as Node<
+                    FullNodeTypesAdapter<N, DB, BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>>,
+                >>::ComponentsBuilder as NodeComponentsBuilder<
+                    FullNodeTypesAdapter<N, DB, BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>>,
+                >>::Components,
+            >,
+            <<N as Node<
+                FullNodeTypesAdapter<N, DB, BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>>,
+            >>::AddOns as RethRpcAddOns<
+                NodeAdapter<
+                    FullNodeTypesAdapter<N, DB, BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>>,
+                    <<N as Node<
+                        FullNodeTypesAdapter<
+                            N,
+                            DB,
+                            BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>,
+                        >,
+                    >>::ComponentsBuilder as NodeComponentsBuilder<
+                        FullNodeTypesAdapter<
+                            N,
+                            DB,
+                            BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>,
+                        >,
+                    >>::Components,
+                >,
+            >>::EthApi,
+        >,
         N::Primitives: FullNodePrimitives,
         EngineNodeLauncher: LaunchNode<
             NodeBuilderWithComponents<RethFullAdapter<DB, N>, N::ComponentsBuilder, N::AddOns>,
@@ -407,6 +448,12 @@ where
     T: FullNodeTypes,
     CB: NodeComponentsBuilder<T>,
     AO: RethRpcAddOns<NodeAdapter<T, CB::Components>>,
+    <AO as reth_node_api::NodeAddOns<
+        NodeAdapter<T, <CB as NodeComponentsBuilder<T>>::Components>,
+    >>::Handle: RpcHandleProvider<
+        NodeAdapter<T, <CB as NodeComponentsBuilder<T>>::Components>,
+        <AO as RethRpcAddOns<NodeAdapter<T, <CB as NodeComponentsBuilder<T>>::Components>>>::EthApi,
+    >,
 {
     /// Returns a reference to the node builder's config.
     pub const fn config(&self) -> &NodeConfig<<T::Types as NodeTypes>::ChainSpec> {

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -356,43 +356,27 @@ where
                 <N::ComponentsBuilder as NodeComponentsBuilder<RethFullAdapter<DB, N>>>::Components,
             >,
         >,
-        <<N as Node<
-            FullNodeTypesAdapter<N, DB, BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>>,
-        >>::AddOns as reth_node_api::NodeAddOns<
+        <<N as Node<RethFullAdapter<DB, N>>>::AddOns as reth_node_api::NodeAddOns<
             NodeAdapter<
-                FullNodeTypesAdapter<N, DB, BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>>,
-                <<N as Node<
-                    FullNodeTypesAdapter<N, DB, BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>>,
-                >>::ComponentsBuilder as NodeComponentsBuilder<
-                    FullNodeTypesAdapter<N, DB, BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>>,
+                RethFullAdapter<DB, N>,
+                <<N as Node<RethFullAdapter<DB, N>>>::ComponentsBuilder as NodeComponentsBuilder<
+                    RethFullAdapter<DB, N>,
                 >>::Components,
             >,
         >>::Handle: RpcHandleProvider<
             NodeAdapter<
-                FullNodeTypesAdapter<N, DB, BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>>,
-                <<N as Node<
-                    FullNodeTypesAdapter<N, DB, BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>>,
-                >>::ComponentsBuilder as NodeComponentsBuilder<
-                    FullNodeTypesAdapter<N, DB, BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>>,
+                RethFullAdapter<DB, N>,
+                <<N as Node<RethFullAdapter<DB, N>>>::ComponentsBuilder as NodeComponentsBuilder<
+                    RethFullAdapter<DB, N>,
                 >>::Components,
             >,
-            <<N as Node<
-                FullNodeTypesAdapter<N, DB, BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>>,
-            >>::AddOns as RethRpcAddOns<
+            <<N as Node<RethFullAdapter<DB, N>>>::AddOns as RethRpcAddOns<
                 NodeAdapter<
-                    FullNodeTypesAdapter<N, DB, BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>>,
+                    RethFullAdapter<DB, N>,
                     <<N as Node<
-                        FullNodeTypesAdapter<
-                            N,
-                            DB,
-                            BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>,
-                        >,
+                        RethFullAdapter<DB, N>,
                     >>::ComponentsBuilder as NodeComponentsBuilder<
-                        FullNodeTypesAdapter<
-                            N,
-                            DB,
-                            BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>,
-                        >,
+                        RethFullAdapter<DB, N>,
                     >>::Components,
                 >,
             >>::EthApi,

--- a/crates/node/builder/src/builder/states.rs
+++ b/crates/node/builder/src/builder/states.rs
@@ -9,7 +9,7 @@ use crate::{
     components::{NodeComponents, NodeComponentsBuilder},
     hooks::NodeHooks,
     launch::LaunchNode,
-    rpc::{RethRpcAddOns, RethRpcServerHandles, RpcContext},
+    rpc::{RethRpcAddOns, RethRpcServerHandles, RpcContext, RpcHandleProvider},
     AddOns, FullNode,
 };
 
@@ -249,6 +249,12 @@ where
     T: FullNodeTypes,
     CB: NodeComponentsBuilder<T>,
     AO: RethRpcAddOns<NodeAdapter<T, CB::Components>>,
+    <AO as reth_node_api::NodeAddOns<
+        NodeAdapter<T, <CB as NodeComponentsBuilder<T>>::Components>,
+    >>::Handle: RpcHandleProvider<
+        NodeAdapter<T, <CB as NodeComponentsBuilder<T>>::Components>,
+        <AO as RethRpcAddOns<NodeAdapter<T, <CB as NodeComponentsBuilder<T>>::Components>>>::EthApi,
+    >,
 {
     /// Launches the node with the given launcher.
     pub async fn launch_with<L>(self, launcher: L) -> eyre::Result<L::Node>

--- a/crates/node/builder/src/handle.rs
+++ b/crates/node/builder/src/handle.rs
@@ -3,11 +3,18 @@ use std::fmt;
 use reth_node_api::FullNodeComponents;
 use reth_node_core::exit::NodeExitFuture;
 
-use crate::{node::FullNode, rpc::RethRpcAddOns};
+use crate::{
+    node::FullNode,
+    rpc::{RethRpcAddOns, RpcHandleProvider},
+};
 
 /// A Handle to the launched node.
 #[must_use = "Needs to await the node exit future"]
-pub struct NodeHandle<Node: FullNodeComponents, AddOns: RethRpcAddOns<Node>> {
+pub struct NodeHandle<Node: FullNodeComponents, AddOns: RethRpcAddOns<Node>>
+where
+    <AddOns as reth_node_api::NodeAddOns<Node>>::Handle:
+        RpcHandleProvider<Node, <AddOns as RethRpcAddOns<Node>>::EthApi>,
+{
     /// All node components.
     pub node: FullNode<Node, AddOns>,
     /// The exit future of the node.
@@ -18,6 +25,8 @@ impl<Node, AddOns> NodeHandle<Node, AddOns>
 where
     Node: FullNodeComponents,
     AddOns: RethRpcAddOns<Node>,
+    <AddOns as reth_node_api::NodeAddOns<Node>>::Handle:
+        RpcHandleProvider<Node, <AddOns as RethRpcAddOns<Node>>::EthApi>,
 {
     /// Waits for the node to exit, if it was configured to exit.
     pub async fn wait_for_node_exit(self) -> eyre::Result<()> {
@@ -29,6 +38,8 @@ impl<Node, AddOns> fmt::Debug for NodeHandle<Node, AddOns>
 where
     Node: FullNodeComponents,
     AddOns: RethRpcAddOns<Node>,
+    <AddOns as reth_node_api::NodeAddOns<Node>>::Handle:
+        RpcHandleProvider<Node, <AddOns as RethRpcAddOns<Node>>::EthApi>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("NodeHandle")

--- a/crates/node/builder/src/launch/debug.rs
+++ b/crates/node/builder/src/launch/debug.rs
@@ -1,6 +1,6 @@
 use super::LaunchNode;
 use crate::{
-    rpc::{BaseAddOnsProvider, BeaconEngineHandleProvider, RethRpcAddOns, RpcHandleProvider},
+    rpc::{RethRpcAddOns, RpcHandleProvider},
     EngineNodeLauncher, Node, NodeHandle,
 };
 use alloy_provider::network::AnyNetwork;
@@ -40,7 +40,7 @@ where
     AddOns: RethRpcAddOns<N>,
     L: LaunchNode<Target, Node = NodeHandle<N, AddOns>>,
     <AddOns as reth_node_api::NodeAddOns<N>>::Handle:
-        BaseAddOnsProvider<N, <AddOns as RethRpcAddOns<N>>::EthApi>,
+        RpcHandleProvider<N, <AddOns as RethRpcAddOns<N>>::EthApi>,
 {
     type Node = NodeHandle<N, AddOns>;
 
@@ -66,7 +66,7 @@ where
                 .await?;
 
             let rpc_consensus_client = DebugConsensusClient::new(
-                handle.node.add_ons_handle.beacon_engine_handle().clone(),
+                handle.node.rpc_handle().beacon_engine_handle.clone(),
                 Arc::new(block_provider),
             );
 
@@ -98,7 +98,7 @@ where
                 N::Types::rpc_to_primitive_block,
             );
             let rpc_consensus_client = DebugConsensusClient::new(
-                handle.node.add_ons_handle.beacon_engine_handle().clone(),
+                handle.node.rpc_handle().beacon_engine_handle.clone(),
                 Arc::new(block_provider),
             );
             handle.node.task_executor.spawn_critical("etherscan consensus client", async move {

--- a/crates/node/builder/src/launch/debug.rs
+++ b/crates/node/builder/src/launch/debug.rs
@@ -1,5 +1,8 @@
 use super::LaunchNode;
-use crate::{rpc::RethRpcAddOns, EngineNodeLauncher, Node, NodeHandle};
+use crate::{
+    rpc::{BaseAddOnsProvider, BeaconEngineHandleProvider, RethRpcAddOns, RpcHandleProvider},
+    EngineNodeLauncher, Node, NodeHandle,
+};
 use alloy_provider::network::AnyNetwork;
 use jsonrpsee::core::{DeserializeOwned, Serialize};
 use reth_chainspec::EthChainSpec;
@@ -36,10 +39,16 @@ where
     N: FullNodeComponents<Types: DebugNode<N>>,
     AddOns: RethRpcAddOns<N>,
     L: LaunchNode<Target, Node = NodeHandle<N, AddOns>>,
+    <AddOns as reth_node_api::NodeAddOns<N>>::Handle:
+        BaseAddOnsProvider<N, <AddOns as RethRpcAddOns<N>>::EthApi>,
 {
     type Node = NodeHandle<N, AddOns>;
 
-    async fn launch_node(self, target: Target) -> eyre::Result<Self::Node> {
+    async fn launch_node(self, target: Target) -> eyre::Result<Self::Node>
+    where
+        <AddOns as reth_node_api::NodeAddOns<N>>::Handle:
+            RpcHandleProvider<N, <AddOns as RethRpcAddOns<N>>::EthApi>,
+    {
         let handle = self.inner.launch_node(target).await?;
 
         let config = &handle.node.config;
@@ -57,7 +66,7 @@ where
                 .await?;
 
             let rpc_consensus_client = DebugConsensusClient::new(
-                handle.node.add_ons_handle.beacon_engine_handle.clone(),
+                handle.node.add_ons_handle.beacon_engine_handle().clone(),
                 Arc::new(block_provider),
             );
 
@@ -89,7 +98,7 @@ where
                 N::Types::rpc_to_primitive_block,
             );
             let rpc_consensus_client = DebugConsensusClient::new(
-                handle.node.add_ons_handle.beacon_engine_handle.clone(),
+                handle.node.add_ons_handle.beacon_engine_handle().clone(),
                 Arc::new(block_provider),
             );
             handle.node.task_executor.spawn_critical("etherscan consensus client", async move {

--- a/crates/node/builder/src/node.rs
+++ b/crates/node/builder/src/node.rs
@@ -1,6 +1,7 @@
 // re-export the node api types
 pub use reth_node_api::{FullNodeTypes, NodeTypes};
 
+use super::rpc::RpcHandleProvider;
 use crate::{components::NodeComponentsBuilder, rpc::RethRpcAddOns, NodeAdapter, NodeAddOns};
 use reth_node_api::{EngineTypes, FullNodeComponents, PayloadTypes};
 use reth_node_core::{
@@ -152,15 +153,17 @@ where
     Payload: PayloadTypes,
     Node: FullNodeComponents<Types: NodeTypes<Payload = Payload>>,
     AddOns: RethRpcAddOns<Node>,
+    <AddOns as reth_node_api::NodeAddOns<Node>>::Handle:
+        RpcHandleProvider<Node, <AddOns as RethRpcAddOns<Node>>::EthApi>,
 {
     /// Returns the [`RpcServerHandle`] to the started rpc server.
-    pub const fn rpc_server_handle(&self) -> &RpcServerHandle {
-        &self.add_ons_handle.rpc_server_handles.rpc
+    pub fn rpc_server_handle(&self) -> &RpcServerHandle {
+        &self.add_ons_handle.rpc_handle().rpc_server_handles.rpc
     }
 
     /// Returns the [`AuthServerHandle`] to the started authenticated engine API server.
-    pub const fn auth_server_handle(&self) -> &AuthServerHandle {
-        &self.add_ons_handle.rpc_server_handles.auth
+    pub fn auth_server_handle(&self) -> &AuthServerHandle {
+        &self.add_ons_handle.rpc_handle().rpc_server_handles.auth
     }
 }
 
@@ -169,6 +172,8 @@ where
     Engine: EngineTypes,
     Node: FullNodeComponents<Types: NodeTypes<Payload = Engine>>,
     AddOns: RethRpcAddOns<Node>,
+    <AddOns as reth_node_api::NodeAddOns<Node>>::Handle:
+        RpcHandleProvider<Node, <AddOns as RethRpcAddOns<Node>>::EthApi>,
 {
     /// Returns the [`EngineApiClient`] interface for the authenticated engine API.
     ///

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -346,6 +346,49 @@ where
     }
 }
 
+/// Trait to provide access to the RPC handle.
+pub trait RpcHandleProvider<Node: FullNodeComponents, EthApi: EthApiTypes> {
+    /// Returns the rpc server handles.
+    fn rpc_handle(&self) -> &RpcHandle<Node, EthApi>;
+}
+
+impl<Node: FullNodeComponents, EthApi: EthApiTypes> RpcHandleProvider<Node, EthApi>
+    for RpcHandle<Node, EthApi>
+{
+    fn rpc_handle(&self) -> &Self {
+        self
+    }
+}
+
+/// Trait to provide access to the beacon engine handle.
+pub trait BeaconEngineHandleProvider<Node: FullNodeComponents, EthApi: EthApiTypes> {
+    /// Returns the beacon engine handle.
+    fn beacon_engine_handle(
+        &self,
+    ) -> &BeaconConsensusEngineHandle<<Node::Types as NodeTypes>::Payload>;
+}
+
+impl<Node: FullNodeComponents, EthApi: EthApiTypes> BeaconEngineHandleProvider<Node, EthApi>
+    for RpcHandle<Node, EthApi>
+{
+    fn beacon_engine_handle(
+        &self,
+    ) -> &BeaconConsensusEngineHandle<<Node::Types as NodeTypes>::Payload> {
+        &self.beacon_engine_handle
+    }
+}
+
+/// Trait that combines the [`RpcHandleProvider`] and [`BeaconEngineHandleProvider`] traits.
+pub trait BaseAddOnsProvider<Node: FullNodeComponents, EthApi: EthApiTypes>:
+    RpcHandleProvider<Node, EthApi> + BeaconEngineHandleProvider<Node, EthApi>
+{
+}
+
+impl<Node: FullNodeComponents, EthApi: EthApiTypes, T> BaseAddOnsProvider<Node, EthApi> for T where
+    T: RpcHandleProvider<Node, EthApi> + BeaconEngineHandleProvider<Node, EthApi>
+{
+}
+
 /// Node add-ons containing RPC server configuration, with customizable eth API handler.
 ///
 /// This struct can be used to provide the RPC server functionality. It is responsible for launching
@@ -586,8 +629,9 @@ where
 
 /// Helper trait implemented for add-ons producing [`RpcHandle`]. Used by common node launcher
 /// implementations.
-pub trait RethRpcAddOns<N: FullNodeComponents>:
-    NodeAddOns<N, Handle = RpcHandle<N, Self::EthApi>>
+pub trait RethRpcAddOns<N: FullNodeComponents>: NodeAddOns<N>
+where
+    Self::Handle: RpcHandleProvider<N, Self::EthApi>,
 {
     /// eth API implementation.
     type EthApi: EthApiTypes;

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -360,35 +360,6 @@ impl<Node: FullNodeComponents, EthApi: EthApiTypes> RpcHandleProvider<Node, EthA
     }
 }
 
-/// Trait to provide access to the beacon engine handle.
-pub trait BeaconEngineHandleProvider<Node: FullNodeComponents, EthApi: EthApiTypes> {
-    /// Returns the beacon engine handle.
-    fn beacon_engine_handle(
-        &self,
-    ) -> &BeaconConsensusEngineHandle<<Node::Types as NodeTypes>::Payload>;
-}
-
-impl<Node: FullNodeComponents, EthApi: EthApiTypes> BeaconEngineHandleProvider<Node, EthApi>
-    for RpcHandle<Node, EthApi>
-{
-    fn beacon_engine_handle(
-        &self,
-    ) -> &BeaconConsensusEngineHandle<<Node::Types as NodeTypes>::Payload> {
-        &self.beacon_engine_handle
-    }
-}
-
-/// Trait that combines the [`RpcHandleProvider`] and [`BeaconEngineHandleProvider`] traits.
-pub trait BaseAddOnsProvider<Node: FullNodeComponents, EthApi: EthApiTypes>:
-    RpcHandleProvider<Node, EthApi> + BeaconEngineHandleProvider<Node, EthApi>
-{
-}
-
-impl<Node: FullNodeComponents, EthApi: EthApiTypes, T> BaseAddOnsProvider<Node, EthApi> for T where
-    T: RpcHandleProvider<Node, EthApi> + BeaconEngineHandleProvider<Node, EthApi>
-{
-}
-
 /// Node add-ons containing RPC server configuration, with customizable eth API handler.
 ///
 /// This struct can be used to provide the RPC server functionality. It is responsible for launching


### PR DESCRIPTION
# Overview
In this PR we refactor the node builder to support generic add ons handle type. This allows us to introduce `ScrollNodeAddOnsHandle` in the rolup node which we can use for testing.  