### PR TITLE
feat: scroll compatibility changes

### DIFF
--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -130,3 +130,13 @@ impl EthChainSpec for ChainSpec {
         self.paris_block_and_final_difficulty.map(|(_, final_difficulty)| final_difficulty)
     }
 }
+
+/// Trait representing the current capacities of the fork.
+pub trait EthCapacity: EthereumHardforks {
+    /// Returns true if the withdrawals are active.
+    fn withdrawals_active(&self, ts: u64) -> bool {
+        self.is_shanghai_active_at_timestamp(ts)
+    }
+}
+
+impl EthCapacity for ChainSpec {}

--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -132,11 +132,11 @@ impl EthChainSpec for ChainSpec {
 }
 
 /// Trait representing the current capacities of the fork.
-pub trait EthereumCapacities: EthereumHardforks {
+pub trait EthereumCapabilities: EthereumHardforks {
     /// Returns true if the withdrawals are active.
     fn withdrawals_active(&self, ts: u64) -> bool {
         self.is_shanghai_active_at_timestamp(ts)
     }
 }
 
-impl EthereumCapacities for ChainSpec {}
+impl EthereumCapabilities for ChainSpec {}

--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -132,11 +132,11 @@ impl EthChainSpec for ChainSpec {
 }
 
 /// Trait representing the current capacities of the fork.
-pub trait EthCapacity: EthereumHardforks {
+pub trait EthereumCapacities: EthereumHardforks {
     /// Returns true if the withdrawals are active.
     fn withdrawals_active(&self, ts: u64) -> bool {
         self.is_shanghai_active_at_timestamp(ts)
     }
 }
 
-impl EthCapacity for ChainSpec {}
+impl EthereumCapacities for ChainSpec {}

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -25,7 +25,7 @@ pub use alloy_chains::{Chain, ChainKind, NamedChain};
 /// Re-export for convenience
 pub use reth_ethereum_forks::*;
 
-pub use api::EthChainSpec;
+pub use api::{EthCapacity, EthChainSpec};
 pub use info::ChainInfo;
 #[cfg(any(test, feature = "test-utils"))]
 pub use spec::test_fork_ids;

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -25,7 +25,7 @@ pub use alloy_chains::{Chain, ChainKind, NamedChain};
 /// Re-export for convenience
 pub use reth_ethereum_forks::*;
 
-pub use api::{EthChainSpec, EthereumCapacities};
+pub use api::{EthChainSpec, EthereumCapabilities};
 pub use info::ChainInfo;
 #[cfg(any(test, feature = "test-utils"))]
 pub use spec::test_fork_ids;

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -25,7 +25,7 @@ pub use alloy_chains::{Chain, ChainKind, NamedChain};
 /// Re-export for convenience
 pub use reth_ethereum_forks::*;
 
-pub use api::{EthCapacity, EthChainSpec};
+pub use api::{EthChainSpec, EthereumCapacities};
 pub use info::ChainInfo;
 #[cfg(any(test, feature = "test-utils"))]
 pub use spec::test_fork_ids;

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -61,7 +61,7 @@ pub use base_sepolia::BASE_SEPOLIA;
 use derive_more::{Constructor, Deref, From, Into};
 use reth_chainspec::{
     BaseFeeParams, BaseFeeParamsKind, ChainSpec, ChainSpecBuilder, DepositContract,
-    DisplayHardforks, EthChainSpec, EthereumCapacities, EthereumHardforks, ForkFilter, ForkId,
+    DisplayHardforks, EthChainSpec, EthereumCapabilities, EthereumHardforks, ForkFilter, ForkId,
     Hardforks, Head,
 };
 use reth_ethereum_forks::{ChainHardforks, EthereumHardfork, ForkCondition};
@@ -287,7 +287,7 @@ impl EthChainSpec for OpChainSpec {
     }
 }
 
-impl EthereumCapacities for OpChainSpec {}
+impl EthereumCapabilities for OpChainSpec {}
 
 impl Hardforks for OpChainSpec {
     fn fork<H: Hardfork>(&self, fork: H) -> ForkCondition {

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -61,7 +61,8 @@ pub use base_sepolia::BASE_SEPOLIA;
 use derive_more::{Constructor, Deref, From, Into};
 use reth_chainspec::{
     BaseFeeParams, BaseFeeParamsKind, ChainSpec, ChainSpecBuilder, DepositContract,
-    DisplayHardforks, EthChainSpec, EthereumHardforks, ForkFilter, ForkId, Hardforks, Head,
+    DisplayHardforks, EthCapacity, EthChainSpec, EthereumHardforks, ForkFilter, ForkId, Hardforks,
+    Head,
 };
 use reth_ethereum_forks::{ChainHardforks, EthereumHardfork, ForkCondition};
 use reth_network_peers::NodeRecord;
@@ -285,6 +286,8 @@ impl EthChainSpec for OpChainSpec {
         self.inner.final_paris_total_difficulty()
     }
 }
+
+impl EthCapacity for OpChainSpec {}
 
 impl Hardforks for OpChainSpec {
     fn fork<H: Hardfork>(&self, fork: H) -> ForkCondition {

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -61,8 +61,8 @@ pub use base_sepolia::BASE_SEPOLIA;
 use derive_more::{Constructor, Deref, From, Into};
 use reth_chainspec::{
     BaseFeeParams, BaseFeeParamsKind, ChainSpec, ChainSpecBuilder, DepositContract,
-    DisplayHardforks, EthCapacity, EthChainSpec, EthereumHardforks, ForkFilter, ForkId, Hardforks,
-    Head,
+    DisplayHardforks, EthChainSpec, EthereumCapacities, EthereumHardforks, ForkFilter, ForkId,
+    Hardforks, Head,
 };
 use reth_ethereum_forks::{ChainHardforks, EthereumHardfork, ForkCondition};
 use reth_network_peers::NodeRecord;
@@ -287,7 +287,7 @@ impl EthChainSpec for OpChainSpec {
     }
 }
 
-impl EthCapacity for OpChainSpec {}
+impl EthereumCapacities for OpChainSpec {}
 
 impl Hardforks for OpChainSpec {
     fn fork<H: Hardfork>(&self, fork: H) -> ForkCondition {

--- a/crates/scroll/alloy/consensus/src/transaction/envelope.rs
+++ b/crates/scroll/alloy/consensus/src/transaction/envelope.rs
@@ -7,7 +7,7 @@ use alloy_eips::{
     eip2930::AccessList,
     eip7702::SignedAuthorization,
 };
-use alloy_primitives::{Address, Bytes, TxKind, B256, U256};
+use alloy_primitives::{Address, Bytes, Signature, TxKind, B256, U256};
 use alloy_rlp::{Decodable, Encodable};
 
 use crate::{ScrollTxType, TxL1Message};
@@ -364,6 +364,17 @@ impl ScrollTxEnvelope {
             Self::Eip1559(t) => t.eip2718_encoded_length(),
             Self::Eip7702(t) => t.eip2718_encoded_length(),
             Self::L1Message(t) => t.eip2718_encoded_length(),
+        }
+    }
+
+    /// Returns the signature for the transaction.
+    pub const fn signature(&self) -> Option<Signature> {
+        match self {
+            Self::Legacy(t) => Some(*t.signature()),
+            Self::Eip2930(t) => Some(*t.signature()),
+            Self::Eip1559(t) => Some(*t.signature()),
+            Self::Eip7702(t) => Some(*t.signature()),
+            Self::L1Message(_) => None,
         }
     }
 }

--- a/crates/scroll/chainspec/src/lib.rs
+++ b/crates/scroll/chainspec/src/lib.rs
@@ -15,8 +15,8 @@ use alloy_genesis::Genesis;
 use alloy_primitives::{B256, U256};
 use derive_more::{Constructor, Deref, From, Into};
 use reth_chainspec::{
-    BaseFeeParams, ChainSpec, ChainSpecBuilder, DepositContract, EthChainSpec, EthereumHardforks,
-    ForkFilter, ForkId, Hardforks, Head,
+    BaseFeeParams, ChainSpec, ChainSpecBuilder, DepositContract, EthCapacity, EthChainSpec,
+    EthereumHardforks, ForkFilter, ForkId, Hardforks, Head,
 };
 use reth_ethereum_forks::{
     ChainHardforks, EthereumHardfork, ForkCondition, ForkFilterKey, ForkHash, Hardfork,
@@ -257,6 +257,13 @@ impl EthChainSpec for ScrollChainSpec {
 
     fn final_paris_total_difficulty(&self) -> Option<U256> {
         self.inner.final_paris_total_difficulty()
+    }
+}
+
+impl EthCapacity for ScrollChainSpec {
+    fn withdrawals_active(&self, _: u64) -> bool {
+        // Scroll doesn't activate withdrawals.
+        false
     }
 }
 

--- a/crates/scroll/chainspec/src/lib.rs
+++ b/crates/scroll/chainspec/src/lib.rs
@@ -15,7 +15,7 @@ use alloy_genesis::Genesis;
 use alloy_primitives::{B256, U256};
 use derive_more::{Constructor, Deref, From, Into};
 use reth_chainspec::{
-    BaseFeeParams, ChainSpec, ChainSpecBuilder, DepositContract, EthCapacity, EthChainSpec,
+    BaseFeeParams, ChainSpec, ChainSpecBuilder, DepositContract, EthChainSpec, EthereumCapacities,
     EthereumHardforks, ForkFilter, ForkId, Hardforks, Head,
 };
 use reth_ethereum_forks::{
@@ -260,7 +260,7 @@ impl EthChainSpec for ScrollChainSpec {
     }
 }
 
-impl EthCapacity for ScrollChainSpec {
+impl EthereumCapacities for ScrollChainSpec {
     fn withdrawals_active(&self, _: u64) -> bool {
         // Scroll doesn't activate withdrawals.
         false

--- a/crates/scroll/chainspec/src/lib.rs
+++ b/crates/scroll/chainspec/src/lib.rs
@@ -15,8 +15,8 @@ use alloy_genesis::Genesis;
 use alloy_primitives::{B256, U256};
 use derive_more::{Constructor, Deref, From, Into};
 use reth_chainspec::{
-    BaseFeeParams, ChainSpec, ChainSpecBuilder, DepositContract, EthChainSpec, EthereumCapacities,
-    EthereumHardforks, ForkFilter, ForkId, Hardforks, Head,
+    BaseFeeParams, ChainSpec, ChainSpecBuilder, DepositContract, EthChainSpec,
+    EthereumCapabilities, EthereumHardforks, ForkFilter, ForkId, Hardforks, Head,
 };
 use reth_ethereum_forks::{
     ChainHardforks, EthereumHardfork, ForkCondition, ForkFilterKey, ForkHash, Hardfork,
@@ -260,7 +260,7 @@ impl EthChainSpec for ScrollChainSpec {
     }
 }
 
-impl EthereumCapacities for ScrollChainSpec {
+impl EthereumCapabilities for ScrollChainSpec {
     fn withdrawals_active(&self, _: u64) -> bool {
         // Scroll doesn't activate withdrawals.
         false

--- a/crates/scroll/evm/src/config.rs
+++ b/crates/scroll/evm/src/config.rs
@@ -288,7 +288,7 @@ mod tests {
             beneficiary: config.chain_spec().config.fee_vault_address.unwrap(),
             timestamp: attributes.timestamp,
             prevrandao: Some(B256::ZERO),
-            difficulty: U256::ZERO,
+            difficulty: U256::ONE,
             basefee: 155157341,
             gas_limit: header.gas_limit,
             blob_excess_gas_and_price: None,

--- a/crates/scroll/evm/src/config.rs
+++ b/crates/scroll/evm/src/config.rs
@@ -107,7 +107,7 @@ where
             number: parent.number() + 1,
             beneficiary: coinbase,
             timestamp: attributes.timestamp,
-            difficulty: U256::ZERO,
+            difficulty: U256::ONE,
             prevrandao: Some(B256::ZERO),
             gas_limit: attributes.gas_limit,
             basefee: attributes.base_fee,

--- a/crates/scroll/node/src/test_utils.rs
+++ b/crates/scroll/node/src/test_utils.rs
@@ -69,7 +69,7 @@ pub fn scroll_payload_attributes(timestamp: u64) -> ScrollPayloadBuilderAttribut
         timestamp,
         prev_randao: B256::ZERO,
         suggested_fee_recipient: Address::ZERO,
-        withdrawals: Some(vec![]),
+        withdrawals: None,
         parent_beacon_block_root: Some(B256::ZERO),
     };
 

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -1,6 +1,6 @@
 //! Contains the main provider types and traits for interacting with the blockchain's storage.
 
-use reth_chainspec::EthereumCapacities;
+use reth_chainspec::EthereumCapabilities;
 use reth_db_api::table::Value;
 use reth_node_types::{FullNodePrimitives, NodeTypes, NodeTypesWithDB};
 
@@ -33,7 +33,7 @@ pub use consistent::ConsistentProvider;
 pub trait NodeTypesForProvider
 where
     Self: NodeTypes<
-        ChainSpec: EthereumCapacities,
+        ChainSpec: EthereumCapabilities,
         Storage: ChainStorage<Self::Primitives>,
         Primitives: FullNodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
     >,
@@ -42,7 +42,7 @@ where
 
 impl<T> NodeTypesForProvider for T where
     T: NodeTypes<
-        ChainSpec: EthereumCapacities,
+        ChainSpec: EthereumCapabilities,
         Storage: ChainStorage<T::Primitives>,
         Primitives: FullNodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
     >

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -1,6 +1,6 @@
 //! Contains the main provider types and traits for interacting with the blockchain's storage.
 
-use reth_chainspec::EthCapacity;
+use reth_chainspec::EthereumCapacities;
 use reth_db_api::table::Value;
 use reth_node_types::{FullNodePrimitives, NodeTypes, NodeTypesWithDB};
 
@@ -33,7 +33,7 @@ pub use consistent::ConsistentProvider;
 pub trait NodeTypesForProvider
 where
     Self: NodeTypes<
-        ChainSpec: EthCapacity,
+        ChainSpec: EthereumCapacities,
         Storage: ChainStorage<Self::Primitives>,
         Primitives: FullNodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
     >,
@@ -42,7 +42,7 @@ where
 
 impl<T> NodeTypesForProvider for T where
     T: NodeTypes<
-        ChainSpec: EthCapacity,
+        ChainSpec: EthereumCapacities,
         Storage: ChainStorage<T::Primitives>,
         Primitives: FullNodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
     >

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -1,6 +1,6 @@
 //! Contains the main provider types and traits for interacting with the blockchain's storage.
 
-use reth_chainspec::EthereumHardforks;
+use reth_chainspec::EthCapacity;
 use reth_db_api::table::Value;
 use reth_node_types::{FullNodePrimitives, NodeTypes, NodeTypesWithDB};
 
@@ -33,7 +33,7 @@ pub use consistent::ConsistentProvider;
 pub trait NodeTypesForProvider
 where
     Self: NodeTypes<
-        ChainSpec: EthereumHardforks,
+        ChainSpec: EthCapacity,
         Storage: ChainStorage<Self::Primitives>,
         Primitives: FullNodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
     >,
@@ -42,7 +42,7 @@ where
 
 impl<T> NodeTypesForProvider for T where
     T: NodeTypes<
-        ChainSpec: EthereumHardforks,
+        ChainSpec: EthCapacity,
         Storage: ChainStorage<T::Primitives>,
         Primitives: FullNodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
     >

--- a/crates/storage/storage-api/src/chain.rs
+++ b/crates/storage/storage-api/src/chain.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 use alloy_consensus::Header;
 use alloy_primitives::BlockNumber;
 use core::marker::PhantomData;
-use reth_chainspec::{ChainSpecProvider, EthereumCapacities, EthereumHardforks};
+use reth_chainspec::{ChainSpecProvider, EthereumCapabilities, EthereumHardforks};
 use reth_db_api::{
     cursor::{DbCursorRO, DbCursorRW},
     models::StoredBlockOmmers,
@@ -146,8 +146,9 @@ where
 
 impl<Provider, T, H> BlockBodyReader<Provider> for EthStorage<T, H>
 where
-    Provider:
-        DBProvider + ChainSpecProvider<ChainSpec: EthereumCapacities> + OmmersProvider<Header = H>,
+    Provider: DBProvider
+        + ChainSpecProvider<ChainSpec: EthereumCapabilities>
+        + OmmersProvider<Header = H>,
     T: SignedTransaction,
     H: FullBlockHeader,
 {

--- a/crates/storage/storage-api/src/chain.rs
+++ b/crates/storage/storage-api/src/chain.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 use alloy_consensus::Header;
 use alloy_primitives::BlockNumber;
 use core::marker::PhantomData;
-use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
+use reth_chainspec::{ChainSpecProvider, EthCapacity, EthereumHardforks};
 use reth_db_api::{
     cursor::{DbCursorRO, DbCursorRW},
     models::StoredBlockOmmers,
@@ -146,8 +146,7 @@ where
 
 impl<Provider, T, H> BlockBodyReader<Provider> for EthStorage<T, H>
 where
-    Provider:
-        DBProvider + ChainSpecProvider<ChainSpec: EthereumHardforks> + OmmersProvider<Header = H>,
+    Provider: DBProvider + ChainSpecProvider<ChainSpec: EthCapacity> + OmmersProvider<Header = H>,
     T: SignedTransaction,
     H: FullBlockHeader,
 {
@@ -168,7 +167,7 @@ where
         for (header, transactions) in inputs {
             // If we are past shanghai, then all blocks should have a withdrawal list,
             // even if empty
-            let withdrawals = if chain_spec.is_shanghai_active_at_timestamp(header.timestamp()) {
+            let withdrawals = if chain_spec.withdrawals_active(header.timestamp()) {
                 withdrawals_cursor
                     .seek_exact(header.number())?
                     .map(|(_, w)| w.withdrawals)

--- a/crates/storage/storage-api/src/chain.rs
+++ b/crates/storage/storage-api/src/chain.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 use alloy_consensus::Header;
 use alloy_primitives::BlockNumber;
 use core::marker::PhantomData;
-use reth_chainspec::{ChainSpecProvider, EthCapacity, EthereumHardforks};
+use reth_chainspec::{ChainSpecProvider, EthereumCapacities, EthereumHardforks};
 use reth_db_api::{
     cursor::{DbCursorRO, DbCursorRW},
     models::StoredBlockOmmers,
@@ -146,7 +146,8 @@ where
 
 impl<Provider, T, H> BlockBodyReader<Provider> for EthStorage<T, H>
 where
-    Provider: DBProvider + ChainSpecProvider<ChainSpec: EthCapacity> + OmmersProvider<Header = H>,
+    Provider:
+        DBProvider + ChainSpecProvider<ChainSpec: EthereumCapacities> + OmmersProvider<Header = H>,
     T: SignedTransaction,
     H: FullBlockHeader,
 {


### PR DESCRIPTION
Implements the following changes to match Scroll network requirements:
- add `EthCapacity` which allows to check specific capacities of the chain spec instead of entire forks.
- Set difficulty to 1 by default for Scroll in block building and payload verification.
- Signature helper to return optional signature of a `ScrollTransactionSigned`.