### PR TITLE
DRAFT: skip block data hints check

### DIFF
--- a/crates/scroll/chainspec/Cargo.toml
+++ b/crates/scroll/chainspec/Cargo.toml
@@ -64,3 +64,4 @@ std = [
     "serde_json/std",
     "scroll-alloy-hardforks/std",
 ]
+test-utils = []

--- a/crates/scroll/chainspec/Cargo.toml
+++ b/crates/scroll/chainspec/Cargo.toml
@@ -64,4 +64,8 @@ std = [
     "serde_json/std",
     "scroll-alloy-hardforks/std",
 ]
-test-utils = []
+test-utils = [
+    "reth-chainspec/test-utils",
+    "reth-primitives-traits/test-utils",
+    "reth-trie-common/test-utils",
+]

--- a/crates/scroll/chainspec/src/constants.rs
+++ b/crates/scroll/chainspec/src/constants.rs
@@ -23,6 +23,8 @@ pub const SCROLL_MAINNET_L1_CONFIG: L1Config = L1Config {
     l1_message_queue_address: SCROLL_MAINNET_L1_MESSAGE_QUEUE_ADDRESS,
     scroll_chain_address: SCROLL_MAINNET_L1_PROXY_ADDRESS,
     num_l1_messages_per_block: SCROLL_MAINNET_MAX_L1_MESSAGES,
+    #[cfg(feature = "test-utils")]
+    bypass_block_data_hint_checks: false,
 };
 
 /// The Scroll Mainnet genesis hash
@@ -48,6 +50,8 @@ pub const SCROLL_SEPOLIA_L1_CONFIG: L1Config = L1Config {
     l1_message_queue_address: SCROLL_SEPOLIA_L1_MESSAGE_QUEUE_ADDRESS,
     scroll_chain_address: SCROLL_SEPOLIA_L1_PROXY_ADDRESS,
     num_l1_messages_per_block: SCROLL_SEPOLIA_MAX_L1_MESSAGES,
+    #[cfg(feature = "test-utils")]
+    bypass_block_data_hint_checks: false,
 };
 
 /// The L1 message queue address for Scroll dev.
@@ -67,6 +71,8 @@ pub const SCROLL_DEV_L1_CONFIG: L1Config = L1Config {
     l1_message_queue_address: SCROLL_DEV_L1_MESSAGE_QUEUE_ADDRESS,
     scroll_chain_address: SCROLL_DEV_L1_PROXY_ADDRESS,
     num_l1_messages_per_block: SCROLL_DEV_MAX_L1_MESSAGES,
+    #[cfg(feature = "test-utils")]
+    bypass_block_data_hint_checks: false,
 };
 
 /// The Scroll Sepolia genesis hash

--- a/crates/scroll/chainspec/src/genesis.rs
+++ b/crates/scroll/chainspec/src/genesis.rs
@@ -90,6 +90,10 @@ pub struct L1Config {
     pub scroll_chain_address: Address,
     /// The maximum number of L1 messages to be consumed per L2 rollup block.
     pub num_l1_messages_per_block: u64,
+    #[cfg(feature = "test-utils")]
+    /// Whether to bypass block data hint checks in the engine-validator. This can only ever be set
+    /// with the `test-utils` feature enabled.
+    pub bypass_block_data_hint_checks: bool,
 }
 
 /// The configuration for the Scroll sequencer chain.
@@ -217,6 +221,8 @@ mod tests {
                     l1_message_queue_address: address!("0d7E906BD9cAFa154b048cFa766Cc1E54E39AF9B"),
                     scroll_chain_address: address!("a13BAF47339d63B743e7Da8741db5456DAc1E556"),
                     num_l1_messages_per_block: 10,
+                    #[cfg(feature = "test-utils")]
+                    bypass_block_data_hint_checks: false,
                 },
             },
         };

--- a/crates/scroll/node/Cargo.toml
+++ b/crates/scroll/node/Cargo.toml
@@ -114,6 +114,7 @@ test-utils = [
     "reth-db/test-utils",
     "reth-revm/test-utils",
     "reth-scroll-node/test-utils",
+    "reth-scroll-chainspec/test-utils",
 ]
 scroll-alloy-traits = [
     "reth-db/scroll-alloy-traits",

--- a/crates/scroll/node/src/builder/engine.rs
+++ b/crates/scroll/node/src/builder/engine.rs
@@ -84,10 +84,22 @@ where
             MessageValidationKind::PayloadAttributes,
         )?;
 
+        // In test cases we allow bypassing the block data hint check.
+        let bypass_check = {
+            #[cfg(feature = "test-utils")]
+            {
+                self.chainspec.config.l1_config.bypass_block_data_hint_checks
+            }
+            #[cfg(not(feature = "test-utils"))]
+            {
+                false
+            }
+        };
+
         // ensure block data hint is present pre euclid.
         let is_euclid_active =
             self.chainspec.is_euclid_active_at_timestamp(attributes.payload_attributes.timestamp);
-        if !is_euclid_active && attributes.block_data_hint.is_none() {
+        if !is_euclid_active && attributes.block_data_hint.is_none() && !bypass_check {
             return Err(EngineObjectValidationError::InvalidParams(
                 "Missing block data hint Pre-Euclid".to_string().into(),
             ));

--- a/crates/scroll/payload/Cargo.toml
+++ b/crates/scroll/payload/Cargo.toml
@@ -83,4 +83,5 @@ test-utils = [
     "reth-chainspec/test-utils",
     "reth-evm/test-utils",
     "reth-revm/test-utils",
+    "reth-scroll-chainspec/test-utils",
 ]


### PR DESCRIPTION
# Overview
I'm currently having trouble downloading block data hints:

```rust
[00:00:00] [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 0 B/1.37 GiB (0.0s)
ts=2025-06-16T14:00:16.660589Z level=info target=reth::cli message=Status connected_peers=5 latest_block=0
ts=2025-06-16T14:00:41.661625Z level=info target=reth::cli message=Status connected_peers=5 latest_block=0
ts=2025-06-16T14:01:06.662717Z level=info target=reth::cli message=Status connected_peers=5 latest_block=0
  [00:01:00] [######################################################################################################################################################################################################] 1.37 GiB/1.37 GiB (0.0s)
thread 'main' panicked at /Users/f/dev/scroll/rollup-node/crates/node/src/add_ons/rollup.rs:143:56:
failed to perform migration: Custom("error decoding response body")
stack backtrace:
   0: __rustc::rust_begin_unwind
```

As such, this is an interim solution to unblock my work on graceful shutdown. In the future we should embed a small sample set such that when we are testing we seed the table from the sample set. We will investigate the download issue to identify root cause. 