### PR TITLE
fix: zkvm reth codec issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10207,7 +10207,6 @@ dependencies = [
  "reth-consensus-common",
  "reth-ethereum-consensus",
  "reth-execution-types",
- "reth-primitives",
  "reth-primitives-traits",
  "reth-scroll-primitives",
  "scroll-alloy-hardforks",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3167,7 +3167,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4446,7 +4446,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -4891,7 +4891,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.1",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6845,7 +6845,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10934,7 +10934,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "24.0.0"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#28f83c2759ac9d2d23969a931cf308b375bb6bd4"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#774616019e9562b12cbe1c3f1cdd110793f8084c"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10952,7 +10952,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "4.0.1"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#28f83c2759ac9d2d23969a931cf308b375bb6bd4"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#774616019e9562b12cbe1c3f1cdd110793f8084c"
 dependencies = [
  "bitvec",
  "once_cell",
@@ -10964,7 +10964,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "5.0.0"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#28f83c2759ac9d2d23969a931cf308b375bb6bd4"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#774616019e9562b12cbe1c3f1cdd110793f8084c"
 dependencies = [
  "cfg-if",
  "derive-where",
@@ -10979,7 +10979,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "5.0.0"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#28f83c2759ac9d2d23969a931cf308b375bb6bd4"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#774616019e9562b12cbe1c3f1cdd110793f8084c"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10994,7 +10994,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "4.0.1"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#28f83c2759ac9d2d23969a931cf308b375bb6bd4"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#774616019e9562b12cbe1c3f1cdd110793f8084c"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -11007,7 +11007,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "4.0.1"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#28f83c2759ac9d2d23969a931cf308b375bb6bd4"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#774616019e9562b12cbe1c3f1cdd110793f8084c"
 dependencies = [
  "auto_impl",
  "revm-primitives",
@@ -11018,7 +11018,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "5.0.0"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#28f83c2759ac9d2d23969a931cf308b375bb6bd4"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#774616019e9562b12cbe1c3f1cdd110793f8084c"
 dependencies = [
  "auto_impl",
  "revm-bytecode",
@@ -11035,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "5.0.0"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#28f83c2759ac9d2d23969a931cf308b375bb6bd4"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#774616019e9562b12cbe1c3f1cdd110793f8084c"
 dependencies = [
  "auto_impl",
  "revm-context",
@@ -11071,7 +11071,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "20.0.0"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#28f83c2759ac9d2d23969a931cf308b375bb6bd4"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#774616019e9562b12cbe1c3f1cdd110793f8084c"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -11082,7 +11082,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "21.0.0"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#28f83c2759ac9d2d23969a931cf308b375bb6bd4"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#774616019e9562b12cbe1c3f1cdd110793f8084c"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -11106,7 +11106,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "19.1.0"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#28f83c2759ac9d2d23969a931cf308b375bb6bd4"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#774616019e9562b12cbe1c3f1cdd110793f8084c"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -11116,7 +11116,7 @@ dependencies = [
 [[package]]
 name = "revm-scroll"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/scroll-revm#54e4e90105d95f14c0d055f0e37bd689b6f22306"
+source = "git+https://github.com/scroll-tech/scroll-revm#0195a04190cef78901ed67c7bc3048114034f366"
 dependencies = [
  "auto_impl",
  "enumn",
@@ -11130,7 +11130,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "4.0.1"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#28f83c2759ac9d2d23969a931cf308b375bb6bd4"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#774616019e9562b12cbe1c3f1cdd110793f8084c"
 dependencies = [
  "bitflags 2.9.1",
  "revm-bytecode",
@@ -11362,7 +11362,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11375,7 +11375,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11442,7 +11442,7 @@ dependencies = [
  "security-framework 3.2.0",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12353,7 +12353,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -524,8 +524,8 @@ alloy-transport-ws = { version = "1.0.9", default-features = false }
 scroll-alloy-consensus = { path = "crates/scroll/alloy/consensus", default-features = false }
 scroll-alloy-evm = { path = "crates/scroll/alloy/evm" }
 scroll-alloy-hardforks = { path = "crates/scroll/alloy/hardforks", default-features = false }
-scroll-alloy-network = { path = "crates/scroll/alloy/network" }
-scroll-alloy-rpc-types = { path = "crates/scroll/alloy/rpc-types" }
+scroll-alloy-network = { path = "crates/scroll/alloy/network", default-features = false }
+scroll-alloy-rpc-types = { path = "crates/scroll/alloy/rpc-types", default-features = false }
 scroll-alloy-rpc-types-engine = { path = "crates/scroll/alloy/rpc-types-engine", default-features = false }
 scroll-alloy-provider = { path = "crates/scroll/alloy/provider" }
 reth-scroll-chainspec = { path = "crates/scroll/chainspec", default-features = false }
@@ -536,7 +536,7 @@ reth-scroll-engine-primitives = { path = "crates/scroll/engine-primitives" }
 reth-scroll-forks = { path = "crates/scroll/hardforks", default-features = false }
 reth-scroll-node = { path = "crates/scroll/node" }
 reth-scroll-payload = { path = "crates/scroll/payload" }
-reth-scroll-primitives = { path = "crates/scroll/primitives" }
+reth-scroll-primitives = { path = "crates/scroll/primitives", default-features = false }
 reth-scroll-rpc = { path = "crates/scroll/rpc" }
 reth-scroll-trie = { path = "crates/scroll/trie" }
 reth-scroll-txpool = { path = "crates/scroll/txpool" }

--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -66,4 +66,3 @@ arbitrary = [
 test-utils = [
     "reth-primitives-traits/test-utils",
 ]
-scroll = []

--- a/crates/scroll/alloy/consensus/Cargo.toml
+++ b/crates/scroll/alloy/consensus/Cargo.toml
@@ -47,10 +47,7 @@ proptest.workspace = true
 test-fuzz.workspace = true
 
 [features]
-default = [
-    "reth-codec",
-    "std",
-]
+default = ["std"]
 std = [
     "serde/std",
     "alloy-primitives/std",

--- a/crates/scroll/alloy/evm/src/lib.rs
+++ b/crates/scroll/alloy/evm/src/lib.rs
@@ -33,7 +33,10 @@ use revm::{
     Context, ExecuteEvm, InspectEvm, Inspector,
 };
 use revm_scroll::{
-    builder::{DefaultScrollContext, MaybeWithEip7702, ScrollBuilder, ScrollContext},
+    builder::{
+        DefaultScrollContext, EuclidEipActivations, FeynmanEipActivations, ScrollBuilder,
+        ScrollContext,
+    },
     instructions::ScrollInstructions,
     precompile::ScrollPrecompileProvider,
     ScrollSpecId, ScrollTransaction,
@@ -230,6 +233,7 @@ impl EvmFactory for ScrollEvmFactory {
                 .with_block(input.block_env)
                 .with_cfg(input.cfg_env)
                 .maybe_with_eip_7702()
+                .maybe_with_eip_7623()
                 .build_scroll_with_inspector(NoOpInspector {})
                 .with_precompiles(PrecompilesMap::from_static(
                     ScrollPrecompileProvider::new_with_spec(spec_id).precompiles(),
@@ -251,6 +255,7 @@ impl EvmFactory for ScrollEvmFactory {
                 .with_block(input.block_env)
                 .with_cfg(input.cfg_env)
                 .maybe_with_eip_7702()
+                .maybe_with_eip_7623()
                 .build_scroll_with_inspector(inspector)
                 .with_precompiles(PrecompilesMap::from_static(
                     ScrollPrecompileProvider::new_with_spec(spec_id).precompiles(),

--- a/crates/scroll/alloy/network/Cargo.toml
+++ b/crates/scroll/alloy/network/Cargo.toml
@@ -12,14 +12,23 @@ exclude.workspace = true
 workspace = true
 
 [dependencies]
-alloy-provider.workspace = true
+alloy-provider = { workspace = true, default-features = false }
 
-scroll-alloy-consensus.workspace = true
-scroll-alloy-rpc-types.workspace = true
+scroll-alloy-consensus = { workspace = true, default-features = false }
+scroll-alloy-rpc-types = { workspace = true, default-features = false }
 
 # alloy
-alloy-consensus.workspace = true
-alloy-network.workspace = true
-alloy-primitives.workspace = true
-alloy-rpc-types-eth.workspace = true
-alloy-signer.workspace = true
+alloy-consensus = { workspace = true, default-features = false }
+alloy-network = { workspace = true, default-features = false }
+alloy-primitives = { workspace = true, default-features = false }
+alloy-rpc-types-eth = { workspace = true, default-features = false }
+alloy-signer = { workspace = true, default-features = false }
+
+[features]
+std = [
+    "alloy-consensus/std",
+    "alloy-primitives/std",
+    "alloy-rpc-types-eth/std",
+    "scroll-alloy-consensus/std",
+    "scroll-alloy-rpc-types/std",
+]

--- a/crates/scroll/alloy/network/src/lib.rs
+++ b/crates/scroll/alloy/network/src/lib.rs
@@ -12,7 +12,7 @@ use alloy_rpc_types_eth::AccessList;
 use scroll_alloy_consensus::{self, ScrollTxEnvelope, ScrollTxType, ScrollTypedTransaction};
 use scroll_alloy_rpc_types::ScrollTransactionRequest;
 
-/// Types for an Scroll-stack network.
+/// Types for a Scroll-stack network.
 #[derive(Clone, Copy, Debug)]
 pub struct Scroll {
     _private: (),

--- a/crates/scroll/alloy/provider/Cargo.toml
+++ b/crates/scroll/alloy/provider/Cargo.toml
@@ -73,4 +73,5 @@ std = [
     "futures-util/std",
     "reth-scroll-chainspec/std",
     "thiserror/std",
+    "scroll-alloy-network/std",
 ]

--- a/crates/scroll/chainspec/Cargo.toml
+++ b/crates/scroll/chainspec/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 
 [dependencies]
 # reth
-reth-chainspec = { workspace = true, features = ["scroll"] }
+reth-chainspec = { workspace = true, default-features = false }
 reth-ethereum-forks = { workspace = true, default-features = false }
 reth-network-peers = { workspace = true, default-features = false }
 reth-primitives-traits = { workspace = true, default-features = false }

--- a/crates/scroll/consensus/Cargo.toml
+++ b/crates/scroll/consensus/Cargo.toml
@@ -22,12 +22,10 @@ reth-consensus.workspace = true
 reth-consensus-common.workspace = true
 reth-ethereum-consensus.workspace = true
 reth-execution-types.workspace = true
-# imported in order to pull in the reth-codec feature for reth-ethereum-primitives
-reth-primitives = { workspace = true, features = ["reth-codec"] }
 reth-primitives-traits.workspace = true
 
 # scroll
-reth-scroll-primitives = { workspace = true, features = ["serde", "reth-codec"] }
+reth-scroll-primitives = { workspace = true, features = ["serde"], default-features = false }
 scroll-alloy-hardforks.workspace = true
 
 # misc

--- a/crates/scroll/consensus/Cargo.toml
+++ b/crates/scroll/consensus/Cargo.toml
@@ -25,7 +25,7 @@ reth-execution-types.workspace = true
 reth-primitives-traits.workspace = true
 
 # scroll
-reth-scroll-primitives = { workspace = true, features = ["serde"], default-features = false }
+reth-scroll-primitives = { workspace = true, default-features = false }
 scroll-alloy-hardforks.workspace = true
 
 # misc

--- a/crates/scroll/engine-primitives/Cargo.toml
+++ b/crates/scroll/engine-primitives/Cargo.toml
@@ -61,4 +61,5 @@ std = [
     "reth-scroll-chainspec/std",
     "scroll-alloy-hardforks/std",
     "scroll-alloy-rpc-types-engine/std",
+    "reth-scroll-primitives/std",
 ]

--- a/crates/scroll/evm/Cargo.toml
+++ b/crates/scroll/evm/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 reth-chainspec.workspace = true
 reth-evm = { workspace = true, features = ["scroll-alloy-traits"] }
 reth-execution-types.workspace = true
-reth-primitives = { workspace = true, features = ["serde-bincode-compat", "reth-codec"] }
+reth-primitives = { workspace = true, features = ["serde-bincode-compat"] }
 reth-primitives-traits.workspace = true
 
 # revm
@@ -27,7 +27,7 @@ revm-scroll.workspace = true
 # scroll
 reth-scroll-chainspec.workspace = true
 reth-scroll-forks.workspace = true
-reth-scroll-primitives = { workspace = true, features = ["serde", "serde-bincode-compat", "reth-codec"] }
+reth-scroll-primitives = { workspace = true, features = ["serde", "serde-bincode-compat"], default-features = false }
 
 # alloy
 alloy-consensus.workspace = true

--- a/crates/scroll/primitives/src/lib.rs
+++ b/crates/scroll/primitives/src/lib.rs
@@ -11,9 +11,6 @@
 
 use once_cell as _;
 
-#[cfg(not(feature = "std"))]
-extern crate alloc as std;
-
 pub mod transaction;
 pub use transaction::{tx_type::ScrollTxType, ScrollTransactionSigned};
 

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -1096,12 +1096,14 @@ pub fn ensure_intrinsic_gas<T: EthPoolTransaction>(
     // TODO(scroll): SpecId is starting to leak from revm to reth. Find a solution to avoid
     // having to add `is_eip_7702_enabled` everywhere.
     let is_eip7702_enabled = true;
+    let is_eip7623_enabled = true;
 
     let gas = revm_interpreter::gas::calculate_initial_tx_gas(
         spec_id,
         transaction.input(),
         transaction.is_create(),
         is_eip7702_enabled,
+        is_eip7623_enabled,
         transaction.access_list().map(|l| l.len()).unwrap_or_default() as u64,
         transaction
             .access_list()

--- a/crates/trie/trie/Cargo.toml
+++ b/crates/trie/trie/Cargo.toml
@@ -18,7 +18,7 @@ reth-primitives-traits.workspace = true
 reth-stages-types.workspace = true
 reth-storage-errors.workspace = true
 reth-trie-sparse.workspace = true
-reth-trie-common = { workspace = true, features = ["rayon"] }
+reth-trie-common.workspace = true
 
 revm-database.workspace = true
 
@@ -64,6 +64,8 @@ proptest-arbitrary-interop.workspace = true
 proptest.workspace = true
 
 [features]
+default = ["rayon"]
+rayon = ["reth-trie-common/rayon"]
 metrics = ["reth-metrics", "dep:metrics"]
 serde = [
     "alloy-primitives/serde",


### PR DESCRIPTION
Fixes a compilation issue for the zkvm team due to the inclusion of the reth-codecs crate. Also bumps the `revm` and `scroll-revm` crates.

Resolves #255 