### PR TITLE
fix: `alloy-trie` breaking change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -495,7 +495,7 @@ alloy-hardforks = "0.2.2"
 alloy-consensus = { version = "1.0.9", default-features = false }
 alloy-contract = { version = "1.0.9", default-features = false }
 alloy-eips = { version = "1.0.9", default-features = false }
-alloy-genesis = { version = "1.0.9", default-features = false }
+alloy-genesis = { version = "1.0.9, <1.0.13", default-features = false }
 alloy-json-rpc = { version = "1.0.9", default-features = false }
 alloy-network = { version = "1.0.9", default-features = false }
 alloy-network-primitives = { version = "1.0.9", default-features = false }


### PR DESCRIPTION
alloy-genesis <1.0.13 depends on alloy-tire ^0.8, while alloy-genesis 1.0.13 depends on alloy-tire ^0.9, cause compile faills.

```
error[E0277]: the trait bound `alloy_trie::TrieAccount: From<GenesisAccount>` is not satisfied
  --> /Users/hhq/.cargo/git/checkouts/reth-2db26ef50c906bfe/57b05a8/crates/chainspec/src/spec.rs:74:21
   |
74 |         state_root: state_root_ref_unhashed(&genesis.alloc),
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `From<GenesisAccount>` is not implemented for `alloy_trie::TrieAccount`
   |
   = note: required for `GenesisAccount` to implement `Into<alloy_trie::TrieAccount>`
note: required by a bound in `alloy_trie::root::state_root_ref_unhashed`
  --> /Users/hhq/.cargo/registry/src/rsproxy.cn-e3de039b2554c837/alloy-trie-0.8.1/src/root.rs:92:43
   |
92 |     pub fn state_root_ref_unhashed<'a, A: Into<TrieAccount> + Clone + 'a>(
   |                                           ^^^^^^^^^^^^^^^^^ required by this bound in `state_root_ref_unhashed`

For more information about this error, try `rustc --explain E0277`.
```