### PR TITLE
fix: `alloy-network` breaking changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -495,9 +495,9 @@ alloy-hardforks = "0.2.2"
 alloy-consensus = { version = "1.0.9", default-features = false }
 alloy-contract = { version = "1.0.9", default-features = false }
 alloy-eips = { version = "1.0.9", default-features = false }
-alloy-genesis = { version = "1.0.9, <1.0.13", default-features = false }
+alloy-genesis = { version = "1.0.9, <1.0.13", default-features = false } # FIXME: when upstream upgrade this
 alloy-json-rpc = { version = "1.0.9", default-features = false }
-alloy-network = { version = "1.0.9, <=1.0.13", default-features = false }
+alloy-network = { version = "1.0.9, <=1.0.13", default-features = false } # FIXME: when upstream upgrade this
 alloy-network-primitives = { version = "1.0.9", default-features = false }
 alloy-provider = { version = "1.0.9", features = ["reqwest"], default-features = false }
 alloy-pubsub = { version = "1.0.9", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -497,7 +497,7 @@ alloy-contract = { version = "1.0.9", default-features = false }
 alloy-eips = { version = "1.0.9", default-features = false }
 alloy-genesis = { version = "1.0.9, <1.0.13", default-features = false }
 alloy-json-rpc = { version = "1.0.9", default-features = false }
-alloy-network = { version = "1.0.9", default-features = false }
+alloy-network = { version = "1.0.9, <=1.0.13", default-features = false }
 alloy-network-primitives = { version = "1.0.9", default-features = false }
 alloy-provider = { version = "1.0.9", features = ["reqwest"], default-features = false }
 alloy-pubsub = { version = "1.0.9", default-features = false }


### PR DESCRIPTION
`alloy-network` introduce a new method [`fn take_nonce(&mut self) -> Option<u64>`](https://docs.rs/alloy-network/1.0.14/alloy_network/trait.TransactionBuilder.html#tymethod.take_nonce) in `1.0.14` breaks the compatibility.

see also, alloy-rs/alloy#2624

please remove the version constraint after upstream upgrade this 