### PR TITLE
feat: update block data

### DIFF
--- a/crates/engine/local/src/payload.rs
+++ b/crates/engine/local/src/payload.rs
@@ -5,6 +5,7 @@ use alloy_primitives::{Address, B256};
 use reth_chainspec::EthereumHardforks;
 use reth_ethereum_engine_primitives::EthPayloadAttributes;
 use reth_payload_primitives::PayloadAttributesBuilder;
+use scroll_alloy_rpc_types_engine::BlockDataHint;
 use std::sync::Arc;
 
 /// The attributes builder for local Ethereum payload.
@@ -75,7 +76,7 @@ where
             payload_attributes: self.build(timestamp),
             transactions: None,
             no_tx_pool: false,
-            block_data_hint: None,
+            block_data_hint: BlockDataHint::none(),
             gas_limit: None,
         }
     }

--- a/crates/engine/local/src/payload.rs
+++ b/crates/engine/local/src/payload.rs
@@ -5,7 +5,6 @@ use alloy_primitives::{Address, B256};
 use reth_chainspec::EthereumHardforks;
 use reth_ethereum_engine_primitives::EthPayloadAttributes;
 use reth_payload_primitives::PayloadAttributesBuilder;
-use scroll_alloy_rpc_types_engine::BlockDataHint;
 use std::sync::Arc;
 
 /// The attributes builder for local Ethereum payload.
@@ -76,7 +75,7 @@ where
             payload_attributes: self.build(timestamp),
             transactions: None,
             no_tx_pool: false,
-            block_data_hint: BlockDataHint::none(),
+            block_data_hint: scroll_alloy_rpc_types_engine::BlockDataHint::none(),
             gas_limit: None,
         }
     }

--- a/crates/scroll/engine-primitives/src/payload/attributes.rs
+++ b/crates/scroll/engine-primitives/src/payload/attributes.rs
@@ -23,9 +23,9 @@ pub struct ScrollPayloadBuilderAttributes {
     /// Decoded transactions and the original EIP-2718 encoded bytes as received in the payload
     /// attributes.
     pub transactions: Vec<WithEncoded<ScrollTransactionSigned>>,
-    /// The pre-Euclid block data hint, necessary for the block builder to derive the correct block
-    /// hash.
-    pub block_data_hint: Option<BlockDataHint>,
+    /// The block data hint, used pre-Euclid by the block builder to derive the correct block
+    /// hash and post-Euclid by the sequencer to set the difficulty of the block.
+    pub block_data_hint: BlockDataHint,
     /// The gas limit for the generated payload.
     pub gas_limit: Option<u64>,
 }
@@ -145,18 +145,21 @@ pub(crate) fn payload_id_scroll(
         }
     }
 
-    if let Some(block_data) = &attributes.block_data_hint {
-        hasher.update(&block_data.extra_data);
-        hasher.update(block_data.state_root.0);
-        if let Some(coinbase) = block_data.coinbase {
-            hasher.update(coinbase);
-        }
-        if let Some(nonce) = block_data.nonce {
-            hasher.update(nonce.to_be_bytes());
-        }
-        hasher.update(block_data.difficulty.to_be_bytes::<32>());
+    if let Some(extra_data) = &attributes.block_data_hint.extra_data {
+        hasher.update(extra_data);
     }
-
+    if let Some(state_root) = &attributes.block_data_hint.state_root {
+        hasher.update(state_root.0);
+    }
+    if let Some(coinbase) = &attributes.block_data_hint.coinbase {
+        hasher.update(coinbase);
+    }
+    if let Some(nonce) = &attributes.block_data_hint.nonce {
+        hasher.update(nonce.to_be_bytes());
+    }
+    if let Some(difficulty) = &attributes.block_data_hint.difficulty {
+        hasher.update(difficulty.to_be_bytes::<32>());
+    }
     if let Some(gas_limit) = attributes.gas_limit {
         hasher.update(gas_limit.to_be_bytes());
     }
@@ -194,13 +197,13 @@ mod tests {
             },
             transactions: Some([bytes!("7ef8f8a0dc19cfa777d90980e4875d0a548a881baaa3f83f14d1bc0d3038bc329350e54194deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e20000f424000000000000000000000000300000000670d6d890000000000000125000000000000000000000000000000000000000000000000000000000000000700000000000000000000000000000000000000000000000000000000000000014bf9181db6e381d4384bbf69c48b0ee0eed23c6ca26143c6d2544f9d39997a590000000000000000000000007f83d659683caf2767fd3c720981d51f5bc365bc")].into()),
             no_tx_pool: false,
-            block_data_hint: Some(BlockDataHint{
-                extra_data: bytes!("476574682f76312e302e302f6c696e75782f676f312e342e32"),
-                state_root: b256!("0x000000000000000000000000000000000000000000000000000000000000dead"),
+            block_data_hint: BlockDataHint{
+                extra_data: Some(bytes!("476574682f76312e302e302f6c696e75782f676f312e342e32")),
+                state_root: Some(b256!("0x000000000000000000000000000000000000000000000000000000000000dead")),
                 coinbase: Some(address!("0x000000000000000000000000000000000000dead")),
                 nonce: Some(u64::MAX),
-                difficulty: U256::from(10)
-            }),
+                difficulty: Some(U256::from(10))
+            },
             gas_limit: Some(10_000_000),
         };
 

--- a/crates/scroll/node/src/builder/engine.rs
+++ b/crates/scroll/node/src/builder/engine.rs
@@ -87,7 +87,7 @@ where
         // ensure block data hint is present pre euclid.
         let is_euclid_active =
             self.chainspec.is_euclid_active_at_timestamp(attributes.payload_attributes.timestamp);
-        if !is_euclid_active && attributes.block_data_hint.is_none() {
+        if !is_euclid_active && attributes.block_data_hint.is_empty() {
             return Err(EngineObjectValidationError::InvalidParams(
                 "Missing block data hint Pre-Euclid".to_string().into(),
             ));

--- a/crates/scroll/node/src/test_utils.rs
+++ b/crates/scroll/node/src/test_utils.rs
@@ -11,6 +11,7 @@ use reth_payload_builder::EthPayloadBuilderAttributes;
 use reth_provider::providers::BlockchainProvider;
 use reth_scroll_chainspec::ScrollChainSpecBuilder;
 use reth_tasks::TaskManager;
+use scroll_alloy_rpc_types_engine::BlockDataHint;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -78,7 +79,7 @@ pub fn scroll_payload_attributes(timestamp: u64) -> ScrollPayloadBuilderAttribut
         payload_attributes: EthPayloadBuilderAttributes::new(B256::ZERO, attributes),
         transactions: vec![],
         no_tx_pool: false,
-        block_data_hint: None,
+        block_data_hint: BlockDataHint::none(),
         gas_limit: None,
     }
 }


### PR DESCRIPTION
Set all the fields of the `BlockDataHint` to `Option`, and use `BlockDataHint` instead of `Option<BlockDataHint>` in the `ScrollPayloadAttributes`. This allows the sequencer to still set the `difficulty` using the `BlockDataHint`, but without overwriting any other field.