### PR TITLE
feat(network): enable add extra-protocol to network component by ScrollNetworkBuilder

### DIFF
--- a/crates/scroll/node/src/builder/network.rs
+++ b/crates/scroll/node/src/builder/network.rs
@@ -19,7 +19,7 @@ use std::fmt::Debug;
 /// The network builder for Scroll.
 #[derive(Debug, Default)]
 pub struct ScrollNetworkBuilder {
-    /// Additional RLPx sub-protocols to be added to the network.
+    /// Additional `RLPx` sub-protocols to be added to the network.
     scroll_sub_protocols: RlpxSubProtocols,
 }
 

--- a/crates/scroll/node/src/builder/network.rs
+++ b/crates/scroll/node/src/builder/network.rs
@@ -1,7 +1,6 @@
 use reth_eth_wire_types::BasicNetworkPrimitives;
 use reth_network::{
-    config::NetworkMode, transform::header::HeaderTransform, NetworkConfig, NetworkHandle,
-    NetworkManager, PeersInfo,
+    config::NetworkMode, protocol::{RlpxSubProtocol, RlpxSubProtocols}, transform::header::HeaderTransform, NetworkConfig, NetworkHandle, NetworkManager, PeersInfo
 };
 use reth_node_api::TxTy;
 use reth_node_builder::{components::NetworkBuilder, BuilderContext, FullNodeTypes};
@@ -15,8 +14,24 @@ use scroll_alloy_hardforks::ScrollHardforks;
 use std::fmt::Debug;
 
 /// The network builder for Scroll.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct ScrollNetworkBuilder;
+#[derive(Debug, Default)]
+pub struct ScrollNetworkBuilder {
+    /// Additional RLPx sub-protocols to be added to the network.
+    scroll_sub_protocols: RlpxSubProtocols,
+}
+
+impl ScrollNetworkBuilder {
+    /// Create a new [`ScrollNetworkBuilder`] with default configuration.
+    pub fn new() -> Self {
+        Self { scroll_sub_protocols: RlpxSubProtocols::default() }
+    }
+
+    /// Add a scroll sub-protocol to the network builder.
+    pub fn with_sub_protocol(mut self, protocol: RlpxSubProtocol) -> Self {
+        self.scroll_sub_protocols.push(protocol);
+        self
+    }
+}
 
 impl<Node, Pool> NetworkBuilder<Node, Pool> for ScrollNetworkBuilder
 where
@@ -46,6 +61,7 @@ where
         let config = NetworkConfig {
             network_mode: NetworkMode::Work,
             header_transform: Box::new(transform),
+            extra_protocols: self.scroll_sub_protocols,
             ..config
         };
 

--- a/crates/scroll/node/src/builder/network.rs
+++ b/crates/scroll/node/src/builder/network.rs
@@ -1,6 +1,9 @@
 use reth_eth_wire_types::BasicNetworkPrimitives;
 use reth_network::{
-    config::NetworkMode, protocol::{RlpxSubProtocol, RlpxSubProtocols}, transform::header::HeaderTransform, NetworkConfig, NetworkHandle, NetworkManager, PeersInfo
+    config::NetworkMode,
+    protocol::{RlpxSubProtocol, RlpxSubProtocols},
+    transform::header::HeaderTransform,
+    NetworkConfig, NetworkHandle, NetworkManager, PeersInfo,
 };
 use reth_node_api::TxTy;
 use reth_node_builder::{components::NetworkBuilder, BuilderContext, FullNodeTypes};

--- a/crates/scroll/node/src/node.rs
+++ b/crates/scroll/node/src/node.rs
@@ -43,7 +43,7 @@ impl ScrollNode {
             .pool(ScrollPoolBuilder::default())
             .executor(ScrollExecutorBuilder::default())
             .payload(BasicPayloadServiceBuilder::new(ScrollPayloadBuilderBuilder::default()))
-            .network(ScrollNetworkBuilder)
+            .network(ScrollNetworkBuilder::new())
             .executor(ScrollExecutorBuilder)
             .consensus(ScrollConsensusBuilder)
     }


### PR DESCRIPTION
This PR aims to fix the [issue](https://github.com/scroll-tech/rollup-node/issues/190).

the root cause is that the node will try handshake will peers as soon as the network component launched, but it will take time for network to process add scroll_wire sub-protocol event.

So add feature here that we can add extra-protocol before we launch the network component.