### PR TITLE
fix: ci runner

### DIFF
--- a/.github/workflows/sync-era.yml
+++ b/.github/workflows/sync-era.yml
@@ -17,8 +17,7 @@ concurrency:
 jobs:
   sync:
     name: sync (${{ matrix.chain.bin }})
-    runs-on:
-      group: Reth
+    runs-on: ubuntu-latest
     env:
       RUST_LOG: info,sync=error
       RUST_BACKTRACE: 1
@@ -64,4 +63,4 @@ jobs:
           ${{ matrix.chain.bin }} stage unwind num-blocks 100 --chain ${{ matrix.chain.chain }}
       - name: Run stage unwind to block hash
         run: |
-          ${{ matrix.chain.bin }} stage unwind to-block ${{ matrix.chain.unwind-target }} --chain ${{ matrix.chain.chain }} 
+          ${{ matrix.chain.bin }} stage unwind to-block ${{ matrix.chain.unwind-target }} --chain ${{ matrix.chain.chain }}

--- a/.github/workflows/sync-era.yml
+++ b/.github/workflows/sync-era.yml
@@ -52,7 +52,7 @@ jobs:
             --chain ${{ matrix.chain.chain }} \
             --debug.tip ${{ matrix.chain.tip }} \
             --debug.max-block ${{ matrix.chain.block }} \
-            --debug.terminate
+            --debug.terminate \
             --era.enable
       - name: Verify the target block hash
         run: |


### PR DESCRIPTION
# Overview
Updates the `sync-era` ci job to use the default `ubuntu-latest` runner.