### PR TITLE
refactor: extract scroll zstd encoder to a crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,8 +1373,8 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
- "zstd",
- "zstd-safe",
+ "zstd 0.13.3",
+ "zstd-safe 7.2.4",
 ]
 
 [[package]]
@@ -8905,7 +8905,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.12",
  "tracing",
- "zstd",
+ "zstd 0.13.3",
 ]
 
 [[package]]
@@ -11037,7 +11037,7 @@ dependencies = [
 name = "reth-zstd-compressors"
 version = "1.5.0"
 dependencies = [
- "zstd",
+ "zstd 0.13.3",
 ]
 
 [[package]]
@@ -11699,8 +11699,9 @@ dependencies = [
  "revm-scroll",
  "scroll-alloy-consensus",
  "scroll-alloy-hardforks",
+ "scroll-encoder",
  "serde",
- "zstd",
+ "zstd 0.13.3",
 ]
 
 [[package]]
@@ -11793,6 +11794,13 @@ dependencies = [
  "arbitrary",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "scroll-encoder"
+version = "0.1.0"
+dependencies = [
+ "zstd 0.13.0",
 ]
 
 [[package]]
@@ -14490,11 +14498,27 @@ dependencies = [
 
 [[package]]
 name = "zstd"
+version = "0.13.0"
+source = "git+https://github.com/scroll-tech/zstd-rs?branch=hack%2Fmul-block#5c0892b6567dab31394d701477183ce9d6a32aca"
+dependencies = [
+ "zstd-safe 7.0.0",
+]
+
+[[package]]
+name = "zstd"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 7.2.4",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.0.0"
+source = "git+https://github.com/scroll-tech/zstd-rs?branch=hack%2Fmul-block#5c0892b6567dab31394d701477183ce9d6a32aca"
+dependencies = [
+ "zstd-sys 2.0.9+zstd.1.5.5",
 ]
 
 [[package]]
@@ -14503,7 +14527,16 @@ version = "7.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
 dependencies = [
- "zstd-sys",
+ "zstd-sys 2.0.15+zstd.1.5.7",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.9+zstd.1.5.5"
+source = "git+https://github.com/scroll-tech/zstd-rs?branch=hack%2Fmul-block#5c0892b6567dab31394d701477183ce9d6a32aca"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11701,7 +11701,6 @@ dependencies = [
  "scroll-alloy-hardforks",
  "scroll-encoder",
  "serde",
- "zstd 0.13.3",
 ]
 
 [[package]]
@@ -11798,7 +11797,7 @@ dependencies = [
 
 [[package]]
 name = "scroll-encoder"
-version = "0.1.0"
+version = "1.5.0"
 dependencies = [
  "zstd 0.13.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10301,6 +10301,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-scroll-encoder"
+version = "1.5.0"
+dependencies = [
+ "zstd 0.13.0",
+]
+
+[[package]]
 name = "reth-scroll-engine-primitives"
 version = "1.5.0"
 dependencies = [
@@ -11694,12 +11701,12 @@ dependencies = [
  "eyre",
  "reth-evm",
  "reth-scroll-chainspec",
+ "reth-scroll-encoder",
  "reth-scroll-evm",
  "revm",
  "revm-scroll",
  "scroll-alloy-consensus",
  "scroll-alloy-hardforks",
- "scroll-encoder",
  "serde",
 ]
 
@@ -11793,13 +11800,6 @@ dependencies = [
  "arbitrary",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "scroll-encoder"
-version = "1.5.0"
-dependencies = [
- "zstd 0.13.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -545,7 +545,7 @@ reth-scroll-primitives = { path = "crates/scroll/primitives", default-features =
 reth-scroll-rpc = { path = "crates/scroll/rpc" }
 reth-scroll-trie = { path = "crates/scroll/trie" }
 reth-scroll-txpool = { path = "crates/scroll/txpool" }
-scroll-encoder = { path = "crates/scroll/encoder", default-features = false }
+reth-scroll-encoder = { path = "crates/scroll/encoder", default-features = false }
 # TODO (scroll): point to crates.io/tag once the crate is published/a tag is created.
 poseidon-bn254 = { git = "https://github.com/scroll-tech/poseidon-bn254", rev = "526a64a", features = ["bn254"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,7 @@ members = [
     "crates/scroll/chainspec",
     "crates/scroll/cli",
     "crates/scroll/consensus",
+    "crates/scroll/encoder",
     "crates/scroll/engine-primitives",
     "crates/scroll/evm",
     "crates/scroll/hardforks",
@@ -544,6 +545,7 @@ reth-scroll-primitives = { path = "crates/scroll/primitives", default-features =
 reth-scroll-rpc = { path = "crates/scroll/rpc" }
 reth-scroll-trie = { path = "crates/scroll/trie" }
 reth-scroll-txpool = { path = "crates/scroll/txpool" }
+scroll-encoder = { path = "crates/scroll/encoder", default-features = false }
 # TODO (scroll): point to crates.io/tag once the crate is published/a tag is created.
 poseidon-bn254 = { git = "https://github.com/scroll-tech/poseidon-bn254", rev = "526a64a", features = ["bn254"] }
 

--- a/crates/scroll/alloy/evm/Cargo.toml
+++ b/crates/scroll/alloy/evm/Cargo.toml
@@ -71,4 +71,4 @@ serde = [
     "scroll-alloy-hardforks/serde",
     "alloy-hardforks/serde",
 ]
-zstd_compression = ["zstd"]
+zstd_compression = []

--- a/crates/scroll/alloy/evm/Cargo.toml
+++ b/crates/scroll/alloy/evm/Cargo.toml
@@ -29,7 +29,7 @@ scroll-alloy-consensus = { workspace = true, default-features = false }
 scroll-alloy-hardforks = { workspace = true, default-features = false }
 
 # scroll
-scroll-encoder = { workspace = true, default-features = false }
+reth-scroll-encoder = { workspace = true, default-features = false }
 
 # misc
 auto_impl = { workspace = true, default-features = false }

--- a/crates/scroll/alloy/evm/Cargo.toml
+++ b/crates/scroll/alloy/evm/Cargo.toml
@@ -28,10 +28,12 @@ revm-scroll = { workspace = true, default-features = false }
 scroll-alloy-consensus = { workspace = true, default-features = false }
 scroll-alloy-hardforks = { workspace = true, default-features = false }
 
+# scroll
+scroll-encoder = { workspace = true, default-features = false }
+
 # misc
 auto_impl = { workspace = true, default-features = false }
 serde = { workspace = true, default-features = false, features = ["derive"], optional = true }
-zstd = { version = "=0.13.3", features = ["experimental"], default-features = false, optional = true }
 
 [dev-dependencies]
 alloy-hardforks.workspace = true

--- a/crates/scroll/alloy/evm/src/tx/compression.rs
+++ b/crates/scroll/alloy/evm/src/tx/compression.rs
@@ -14,34 +14,7 @@ mod zstd_compression {
     use std::io::Write;
 
     use revm_scroll::l1block::TX_L1_FEE_PRECISION_U256;
-    use zstd::{
-        stream::Encoder,
-        zstd_safe::{CParameter, ParamSwitch},
-    };
-
-    /// The maximum size of the compression window in bytes (`2^CL_WINDOW_LIMIT`).
-    const CL_WINDOW_LIMIT: u32 = 22;
-
-    /// The zstd block size target.
-    const N_BLOCK_SIZE_TARGET: u32 = 124 * 1024;
-
-    fn compressor(target_block_size: u32) -> Encoder<'static, Vec<u8>> {
-        let mut encoder = Encoder::new(Vec::new(), 0).expect("Failed to create zstd encoder");
-        encoder
-            .set_parameter(CParameter::LiteralCompressionMode(ParamSwitch::Disable))
-            .expect("Failed to set literal compression mode");
-        encoder
-            .set_parameter(CParameter::WindowLog(CL_WINDOW_LIMIT))
-            .expect("Failed to set window log");
-        encoder
-            .set_parameter(CParameter::TargetCBlockSize(target_block_size))
-            .expect("Failed to set target block size");
-        encoder.include_checksum(false).expect("Failed to disable checksum");
-        encoder.include_magicbytes(false).expect("Failed to disable magic bytes");
-        encoder.include_dictid(false).expect("Failed to disable dictid");
-        encoder.include_contentsize(true).expect("Failed to include content size");
-        encoder
-    }
+    use scroll_encoder::{compressor, N_BLOCK_SIZE_TARGET};
 
     /// Computes the compression ratio for the provided bytes.
     ///

--- a/crates/scroll/alloy/evm/src/tx/compression.rs
+++ b/crates/scroll/alloy/evm/src/tx/compression.rs
@@ -14,7 +14,7 @@ mod zstd_compression {
     use std::io::Write;
 
     use revm_scroll::l1block::TX_L1_FEE_PRECISION_U256;
-    use scroll_encoder::{compressor, N_BLOCK_SIZE_TARGET};
+    use reth_scroll_encoder::{compressor, N_BLOCK_SIZE_TARGET};
 
     /// Computes the compression ratio for the provided bytes.
     ///

--- a/crates/scroll/encoder/Cargo.toml
+++ b/crates/scroll/encoder/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "scroll-encoder"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+
+[dependencies]
+zstd = { git = "https://github.com/scroll-tech/zstd-rs", branch = "hack/mul-block", features = ["experimental"]}

--- a/crates/scroll/encoder/Cargo.toml
+++ b/crates/scroll/encoder/Cargo.toml
@@ -1,10 +1,15 @@
 [package]
 name = "scroll-encoder"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Zstd encoder implementation for scroll."
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-[lib]
+[lints]
+workspace = true
 
 [dependencies]
 zstd = { git = "https://github.com/scroll-tech/zstd-rs", branch = "hack/mul-block", features = ["experimental"]}

--- a/crates/scroll/encoder/Cargo.toml
+++ b/crates/scroll/encoder/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "scroll-encoder"
+name = "reth-scroll-encoder"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/scroll/encoder/src/lib.rs
+++ b/crates/scroll/encoder/src/lib.rs
@@ -1,8 +1,15 @@
-use zstd::stream::Encoder;
-use zstd::zstd_safe::{CParameter, ParamSwitch};
+//! Zstd encoder implementation for Scroll.
+//! 
+//! This crate provides a specialized zstd encoder configured for Scroll's compression needs.
 
-// we use offset window no more than = 17
-// TODO: use for multi-block zstd.
+use zstd::{
+    stream::Encoder,
+    zstd_safe::{CParameter, ParamSwitch},
+};
+
+/// Maximum window log limit for zstd compression.
+/// 
+/// We use offset window no more than 17 for Scroll's compression requirements.
 #[allow(dead_code)]
 pub const CL_WINDOW_LIMIT: usize = 17;
 
@@ -21,13 +28,9 @@ pub fn compressor(target_block_size: u32) -> Encoder<'static, Vec<u8>> {
         .set_parameter(CParameter::LiteralCompressionMode(ParamSwitch::Disable))
         .expect("infallible");
     // with a hack in zstd we can set window log <= 17 with single segment kept
-    encoder
-        .set_parameter(CParameter::WindowLog(CL_WINDOW_LIMIT as u32))
-        .expect("infallible");
+    encoder.set_parameter(CParameter::WindowLog(CL_WINDOW_LIMIT as u32)).expect("infallible");
     // set target block size to fit within a single block.
-    encoder
-        .set_parameter(CParameter::TargetCBlockSize(target_block_size))
-        .expect("infallible");
+    encoder.set_parameter(CParameter::TargetCBlockSize(target_block_size)).expect("infallible");
     // do not include the checksum at the end of the encoded data.
     encoder.include_checksum(false).expect("infallible");
     // do not include magic bytes at the start of the frame since we will have a single

--- a/crates/scroll/encoder/src/lib.rs
+++ b/crates/scroll/encoder/src/lib.rs
@@ -1,0 +1,43 @@
+use zstd::stream::Encoder;
+use zstd::zstd_safe::{CParameter, ParamSwitch};
+
+// we use offset window no more than = 17
+// TODO: use for multi-block zstd.
+#[allow(dead_code)]
+pub const CL_WINDOW_LIMIT: usize = 17;
+
+/// zstd block size target.
+pub const N_BLOCK_SIZE_TARGET: u32 = 124 * 1024;
+
+/// Maximum number of blocks that we can expect in the encoded data.
+pub const N_MAX_BLOCKS: u64 = 10;
+
+/// Zstd encoder
+pub fn compressor(target_block_size: u32) -> Encoder<'static, Vec<u8>> {
+    let mut encoder = Encoder::new(Vec::new(), 0).expect("infallible");
+
+    // disable compression of literals, i.e. literals will be raw bytes.
+    encoder
+        .set_parameter(CParameter::LiteralCompressionMode(ParamSwitch::Disable))
+        .expect("infallible");
+    // with a hack in zstd we can set window log <= 17 with single segment kept
+    encoder
+        .set_parameter(CParameter::WindowLog(CL_WINDOW_LIMIT as u32))
+        .expect("infallible");
+    // set target block size to fit within a single block.
+    encoder
+        .set_parameter(CParameter::TargetCBlockSize(target_block_size))
+        .expect("infallible");
+    // do not include the checksum at the end of the encoded data.
+    encoder.include_checksum(false).expect("infallible");
+    // do not include magic bytes at the start of the frame since we will have a single
+    // frame.
+    encoder.include_magicbytes(false).expect("infallible");
+    // do not include dictionary id so we have more simple content
+    encoder.include_dictid(false).expect("infallible");
+    // include the content size to know at decode time the expected size of decoded
+    // data.
+    encoder.include_contentsize(true).expect("infallible");
+
+    encoder
+}


### PR DESCRIPTION
This PR extracts scroll-zstd-encoder to a crate for both Reth, da-codec(l2geth) and prover to use.

See da-codec zsdt encoder here: https://github.com/scroll-tech/da-codec/blob/main/libzstd/encoder-standard/src/lib.rs