### PR TITLE
refactor: make tx forwarding to sequencer non-blocking if tx propagation enabled

### DIFF
--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -493,6 +493,11 @@ where
         }
     }
 
+    /// Returns a mutable reference to the eth API builder.
+    pub fn eth_api_builder(&mut self) -> &mut EthB {
+        &mut self.eth_api_builder
+    }
+
     /// Maps the [`EngineApiBuilder`] builder type.
     pub fn with_engine_api<T>(
         self,

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -442,7 +442,7 @@ pub struct RpcAddOns<
     /// Additional RPC add-ons.
     pub hooks: RpcHooks<Node, EthB::EthApi>,
     /// Builder for `EthApi`
-    eth_api_builder: EthB,
+    pub eth_api_builder: EthB,
     /// Engine validator
     engine_validator_builder: EV,
     /// Builder for `EngineApi`
@@ -491,11 +491,6 @@ where
             engine_api_builder,
             rpc_middleware,
         }
-    }
-
-    /// Returns a mutable reference to the eth API builder.
-    pub fn eth_api_builder(&mut self) -> &mut EthB {
-        &mut self.eth_api_builder
     }
 
     /// Maps the [`EngineApiBuilder`] builder type.

--- a/crates/scroll/node/src/addons.rs
+++ b/crates/scroll/node/src/addons.rs
@@ -17,7 +17,10 @@ use reth_scroll_chainspec::ScrollChainSpec;
 use reth_scroll_engine_primitives::ScrollEngineTypes;
 use reth_scroll_evm::ScrollNextBlockEnvAttributes;
 use reth_scroll_primitives::ScrollPrimitives;
-use reth_scroll_rpc::{eth::ScrollEthApiBuilder, ScrollEthApiError};
+use reth_scroll_rpc::{
+    eth::{ScrollEthApiBuilder, DEFAULT_MIN_SUGGESTED_PRIORITY_FEE},
+    ScrollEthApiError,
+};
 use revm::context::TxEnv;
 use scroll_alloy_evm::ScrollTransactionIntoTxEnv;
 use scroll_alloy_network::Scroll;
@@ -137,6 +140,8 @@ pub struct ScrollAddOnsBuilder<NetworkT, RpcMiddleware = Identity> {
     min_suggested_priority_fee: u64,
     /// Maximum payload size
     payload_size_limit: u64,
+    /// whether local transactions should be propagated.
+    propagate_local_transactions: bool,
     /// Marker for network types.
     _nt: PhantomData<NetworkT>,
     /// RPC middleware to use
@@ -147,9 +152,9 @@ impl<NetworkT> Default for ScrollAddOnsBuilder<NetworkT> {
     fn default() -> Self {
         Self {
             sequencer_url: None,
+            min_suggested_priority_fee: DEFAULT_MIN_SUGGESTED_PRIORITY_FEE,
             payload_size_limit: SCROLL_DEFAULT_PAYLOAD_SIZE_LIMIT,
-            // TODO (scroll): update with default values.
-            min_suggested_priority_fee: 1_000_000,
+            propagate_local_transactions: true,
             _nt: PhantomData,
             rpc_middleware: Identity::new(),
         }
@@ -178,13 +183,30 @@ impl<NetworkT, RpcMiddleWare> ScrollAddOnsBuilder<NetworkT, RpcMiddleWare> {
         self
     }
 
+    /// With whether local transactions should be propagated.
+    pub const fn with_propagate_local_transactions(
+        mut self,
+        propagate_local_transactions: bool,
+    ) -> Self {
+        self.propagate_local_transactions = propagate_local_transactions;
+        self
+    }
+
     /// Configure the RPC middleware to use
     pub fn with_rpc_middleware<T>(self, rpc_middleware: T) -> ScrollAddOnsBuilder<NetworkT, T> {
-        let Self { sequencer_url, min_suggested_priority_fee, payload_size_limit, _nt, .. } = self;
+        let Self {
+            sequencer_url,
+            min_suggested_priority_fee,
+            payload_size_limit,
+            propagate_local_transactions,
+            _nt,
+            ..
+        } = self;
         ScrollAddOnsBuilder {
             sequencer_url,
             payload_size_limit,
             min_suggested_priority_fee,
+            propagate_local_transactions,
             _nt,
             rpc_middleware,
         }

--- a/crates/scroll/node/src/addons.rs
+++ b/crates/scroll/node/src/addons.rs
@@ -17,7 +17,10 @@ use reth_scroll_chainspec::ScrollChainSpec;
 use reth_scroll_engine_primitives::ScrollEngineTypes;
 use reth_scroll_evm::ScrollNextBlockEnvAttributes;
 use reth_scroll_primitives::ScrollPrimitives;
-use reth_scroll_rpc::{eth::{ScrollEthApiBuilder, DEFAULT_MIN_SUGGESTED_PRIORITY_FEE}, ScrollEthApiError};
+use reth_scroll_rpc::{
+    eth::{ScrollEthApiBuilder, DEFAULT_MIN_SUGGESTED_PRIORITY_FEE},
+    ScrollEthApiError,
+};
 use revm::context::TxEnv;
 use scroll_alloy_evm::ScrollTransactionIntoTxEnv;
 use scroll_alloy_network::Scroll;

--- a/crates/scroll/node/src/addons.rs
+++ b/crates/scroll/node/src/addons.rs
@@ -17,10 +17,7 @@ use reth_scroll_chainspec::ScrollChainSpec;
 use reth_scroll_engine_primitives::ScrollEngineTypes;
 use reth_scroll_evm::ScrollNextBlockEnvAttributes;
 use reth_scroll_primitives::ScrollPrimitives;
-use reth_scroll_rpc::{
-    eth::{ScrollEthApiBuilder, DEFAULT_MIN_SUGGESTED_PRIORITY_FEE},
-    ScrollEthApiError,
-};
+use reth_scroll_rpc::{eth::{ScrollEthApiBuilder, DEFAULT_MIN_SUGGESTED_PRIORITY_FEE}, ScrollEthApiError};
 use revm::context::TxEnv;
 use scroll_alloy_evm::ScrollTransactionIntoTxEnv;
 use scroll_alloy_network::Scroll;
@@ -140,8 +137,6 @@ pub struct ScrollAddOnsBuilder<NetworkT, RpcMiddleware = Identity> {
     min_suggested_priority_fee: u64,
     /// Maximum payload size
     payload_size_limit: u64,
-    /// whether local transactions should be propagated.
-    propagate_local_transactions: bool,
     /// Marker for network types.
     _nt: PhantomData<NetworkT>,
     /// RPC middleware to use
@@ -152,9 +147,8 @@ impl<NetworkT> Default for ScrollAddOnsBuilder<NetworkT> {
     fn default() -> Self {
         Self {
             sequencer_url: None,
-            min_suggested_priority_fee: DEFAULT_MIN_SUGGESTED_PRIORITY_FEE,
             payload_size_limit: SCROLL_DEFAULT_PAYLOAD_SIZE_LIMIT,
-            propagate_local_transactions: true,
+            min_suggested_priority_fee: DEFAULT_MIN_SUGGESTED_PRIORITY_FEE,
             _nt: PhantomData,
             rpc_middleware: Identity::new(),
         }
@@ -183,30 +177,13 @@ impl<NetworkT, RpcMiddleWare> ScrollAddOnsBuilder<NetworkT, RpcMiddleWare> {
         self
     }
 
-    /// With whether local transactions should be propagated.
-    pub const fn with_propagate_local_transactions(
-        mut self,
-        propagate_local_transactions: bool,
-    ) -> Self {
-        self.propagate_local_transactions = propagate_local_transactions;
-        self
-    }
-
     /// Configure the RPC middleware to use
     pub fn with_rpc_middleware<T>(self, rpc_middleware: T) -> ScrollAddOnsBuilder<NetworkT, T> {
-        let Self {
-            sequencer_url,
-            min_suggested_priority_fee,
-            payload_size_limit,
-            propagate_local_transactions,
-            _nt,
-            ..
-        } = self;
+        let Self { sequencer_url, min_suggested_priority_fee, payload_size_limit, _nt, .. } = self;
         ScrollAddOnsBuilder {
             sequencer_url,
             payload_size_limit,
             min_suggested_priority_fee,
-            propagate_local_transactions,
             _nt,
             rpc_middleware,
         }

--- a/crates/scroll/rpc/src/eth/mod.rs
+++ b/crates/scroll/rpc/src/eth/mod.rs
@@ -65,12 +65,14 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> ScrollEthApi<N, Rpc> {
         sequencer_client: Option<SequencerClient>,
         min_suggested_priority_fee: U256,
         payload_size_limit: u64,
+        propagate_local_transactions: bool,
     ) -> Self {
         let inner = Arc::new(ScrollEthApiInner {
             eth_api,
             min_suggested_priority_fee,
             payload_size_limit,
             sequencer_client,
+            propagate_local_transactions,
         });
         Self { inner }
     }
@@ -277,6 +279,8 @@ pub struct ScrollEthApiInner<N: ScrollNodeCore, Rpc: RpcConvert> {
     min_suggested_priority_fee: U256,
     /// Maximum payload size
     payload_size_limit: u64,
+    /// whether local transactions should be propagated.
+    propagate_local_transactions: bool,
 }
 
 impl<N: RpcNodeCore, Rpc: RpcConvert> ScrollEthApiInner<N, Rpc> {
@@ -379,7 +383,13 @@ where
     type EthApi = ScrollEthApi<N, ScrollRpcConvert<N, NetworkT>>;
 
     async fn build_eth_api(self, ctx: EthApiCtx<'_, N>) -> eyre::Result<Self::EthApi> {
-        let Self { min_suggested_priority_fee, payload_size_limit, sequencer_url, .. } = self;
+        let Self {
+            min_suggested_priority_fee,
+            payload_size_limit,
+            sequencer_url,
+            propagate_local_transactions,
+            ..
+        } = self;
         let rpc_converter = RpcConverter::new(ScrollReceiptConverter::default())
             .with_mapper(ScrollTxInfoMapper::new(ctx.components.provider().clone()));
 
@@ -400,6 +410,7 @@ where
             sequencer_client,
             U256::from(min_suggested_priority_fee),
             payload_size_limit,
+            propagate_local_transactions,
         ))
     }
 }

--- a/crates/scroll/rpc/src/eth/mod.rs
+++ b/crates/scroll/rpc/src/eth/mod.rs
@@ -307,7 +307,7 @@ pub const DEFAULT_MIN_SUGGESTED_PRIORITY_FEE: u64 = 100;
 pub const DEFAULT_PAYLOAD_SIZE_LIMIT: u64 = 122_880;
 
 /// A type that knows how to build a [`ScrollEthApi`].
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ScrollEthApiBuilder<NetworkT = Scroll> {
     /// Sequencer client, configured to forward submitted transactions to sequencer of given Scroll
     /// network.
@@ -359,7 +359,10 @@ impl<NetworkT> ScrollEthApiBuilder<NetworkT> {
     }
 
     /// With whether local transactions should be propagated.
-    pub const fn with_propagate_local_transactions(mut self, propagate_local_transactions: bool) -> Self {
+    pub const fn with_propagate_local_transactions(
+        mut self,
+        propagate_local_transactions: bool,
+    ) -> Self {
         self.propagate_local_transactions = propagate_local_transactions;
         self
     }

--- a/crates/scroll/rpc/src/eth/mod.rs
+++ b/crates/scroll/rpc/src/eth/mod.rs
@@ -316,6 +316,8 @@ pub struct ScrollEthApiBuilder<NetworkT = Scroll> {
     min_suggested_priority_fee: u64,
     /// Maximum payload size
     payload_size_limit: u64,
+    /// whether local transactions should be propagated.
+    propagate_local_transactions: bool,
     /// Marker for network types.
     _nt: PhantomData<NetworkT>,
 }
@@ -326,6 +328,7 @@ impl<NetworkT> Default for ScrollEthApiBuilder<NetworkT> {
             sequencer_url: None,
             min_suggested_priority_fee: DEFAULT_MIN_SUGGESTED_PRIORITY_FEE,
             payload_size_limit: DEFAULT_PAYLOAD_SIZE_LIMIT,
+            propagate_local_transactions: true,
             _nt: PhantomData,
         }
     }
@@ -352,6 +355,12 @@ impl<NetworkT> ScrollEthApiBuilder<NetworkT> {
     /// With payload size limit
     pub const fn with_payload_size_limit(mut self, limit: u64) -> Self {
         self.payload_size_limit = limit;
+        self
+    }
+
+    /// With whether local transactions should be propagated.
+    pub const fn with_propagate_local_transactions(mut self, propagate_local_transactions: bool) -> Self {
+        self.propagate_local_transactions = propagate_local_transactions;
         self
     }
 }

--- a/crates/scroll/rpc/src/eth/mod.rs
+++ b/crates/scroll/rpc/src/eth/mod.rs
@@ -360,9 +360,9 @@ impl<NetworkT> ScrollEthApiBuilder<NetworkT> {
 
     /// With whether local transactions should be propagated.
     pub const fn with_propagate_local_transactions(
-        mut self,
+        &mut self,
         propagate_local_transactions: bool,
-    ) -> Self {
+    ) -> &mut Self {
         self.propagate_local_transactions = propagate_local_transactions;
         self
     }

--- a/crates/scroll/rpc/src/eth/mod.rs
+++ b/crates/scroll/rpc/src/eth/mod.rs
@@ -311,7 +311,7 @@ pub const DEFAULT_MIN_SUGGESTED_PRIORITY_FEE: u64 = 100;
 pub const DEFAULT_PAYLOAD_SIZE_LIMIT: u64 = 122_880;
 
 /// A type that knows how to build a [`ScrollEthApi`].
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ScrollEthApiBuilder<NetworkT = Scroll> {
     /// Sequencer client, configured to forward submitted transactions to sequencer of given Scroll
     /// network.

--- a/crates/scroll/rpc/src/eth/transaction.rs
+++ b/crates/scroll/rpc/src/eth/transaction.rs
@@ -49,7 +49,6 @@ where
             if self.inner.propagate_local_transactions {
                 // Forward to remote sequencer RPC asynchronously (fire and forget)
                 let client = client.clone();
-                let tx = tx.clone();
                 tokio::spawn(async move {
                     match client.forward_raw_transaction(&tx).await {
                         Ok(sequencer_hash) => {

--- a/crates/scroll/rpc/src/eth/transaction.rs
+++ b/crates/scroll/rpc/src/eth/transaction.rs
@@ -34,39 +34,46 @@ where
         let recovered = recover_raw_transaction(&tx)?;
         let pool_transaction = <Self::Pool as TransactionPool>::Transaction::from_pooled(recovered);
 
-        // On scroll, transactions are forwarded directly to the sequencer to be included in
-        // blocks that it builds.
-        if let Some(client) = self.raw_tx_forwarder().as_ref() {
-            tracing::debug!(target: "scroll::rpc::eth", hash = %pool_transaction.hash(), "forwarding raw transaction to sequencer");
-
-            // Retain tx in local tx pool before forwarding to sequencer rpc, for local RPC usage.
-            let AddedTransactionOutcome { hash, .. } = self
-                .pool()
-                .add_transaction(TransactionOrigin::Local, pool_transaction.clone())
-                .await
-                .map_err(Self::Error::from_eth_err)?;
-
-            tracing::debug!(target: "scroll::rpc::eth", %hash, "successfully added transaction to local tx pool");
-
-            // Forward to remote sequencer RPC.
-            match client.forward_raw_transaction(&tx).await {
-                Ok(sequencer_hash) => {
-                    tracing::debug!(target: "scroll::rpc::eth", local_hash=%hash, sequencer_hash=%sequencer_hash, "successfully forwarded transaction to sequencer");
-                }
-                Err(err) => {
-                    tracing::warn!(target: "scroll::rpc::eth", %err, %hash, "failed to forward transaction to sequencer, but transaction is in local pool");
-                }
-            }
-
-            return Ok(hash);
-        }
-
         // submit the transaction to the pool with a `Local` origin
         let AddedTransactionOutcome { hash, .. } = self
             .pool()
-            .add_transaction(TransactionOrigin::Local, pool_transaction)
+            .add_transaction(TransactionOrigin::Local, pool_transaction.clone())
             .await
             .map_err(Self::Error::from_eth_err)?;
+
+        // On scroll, transactions are forwarded directly to the sequencer to be included in
+        // blocks that it builds.
+        if let Some(client) = self.raw_tx_forwarder() {
+            tracing::debug!(target: "scroll::rpc::eth", hash = %pool_transaction.hash(), "forwarding raw transaction to sequencer");
+
+            if self.inner.propagate_local_transactions {
+                // Forward to remote sequencer RPC asynchronously (fire and forget)
+                let client = client.clone();
+                let tx_clone = tx.clone();
+                let hash_clone = hash;
+                tokio::spawn(async move {
+                    match client.forward_raw_transaction(&tx_clone).await {
+                        Ok(sequencer_hash) => {
+                            tracing::debug!(target: "scroll::rpc::eth", local_hash=%hash_clone, sequencer_hash=%sequencer_hash, "successfully forwarded transaction to sequencer");
+                        }
+                        Err(err) => {
+                            tracing::warn!(target: "scroll::rpc::eth", %err, %hash_clone, "failed to forward transaction to sequencer, but transaction is in local pool and will be propagated");
+                        }
+                    }
+                });
+            } else {
+                // Forward to remote sequencer RPC synchronously
+                match client.forward_raw_transaction(&tx).await {
+                    Ok(sequencer_hash) => {
+                        tracing::debug!(target: "scroll::rpc::eth", local_hash=%hash, sequencer_hash=%sequencer_hash, "successfully forwarded transaction to sequencer");
+                    }
+                    Err(err) => {
+                        tracing::warn!(target: "scroll::rpc::eth", %err, %hash, "failed to forward transaction to sequencer");
+                        return Err(ScrollEthApiError::Sequencer(err));
+                    }
+                }
+            }
+        }
 
         Ok(hash)
     }

--- a/crates/scroll/rpc/src/eth/transaction.rs
+++ b/crates/scroll/rpc/src/eth/transaction.rs
@@ -49,15 +49,14 @@ where
             if self.inner.propagate_local_transactions {
                 // Forward to remote sequencer RPC asynchronously (fire and forget)
                 let client = client.clone();
-                let tx_clone = tx.clone();
-                let hash_clone = hash;
+                let tx = tx.clone();
                 tokio::spawn(async move {
-                    match client.forward_raw_transaction(&tx_clone).await {
+                    match client.forward_raw_transaction(&tx).await {
                         Ok(sequencer_hash) => {
-                            tracing::debug!(target: "scroll::rpc::eth", local_hash=%hash_clone, sequencer_hash=%sequencer_hash, "successfully forwarded transaction to sequencer");
+                            tracing::debug!(target: "scroll::rpc::eth", local_hash=%hash, %sequencer_hash, "successfully forwarded transaction to sequencer");
                         }
                         Err(err) => {
-                            tracing::warn!(target: "scroll::rpc::eth", %err, %hash_clone, "failed to forward transaction to sequencer, but transaction is in local pool and will be propagated");
+                            tracing::warn!(target: "scroll::rpc::eth", %err, local_hash=%hash, "failed to forward transaction to sequencer, but transaction is in local pool and will be propagated");
                         }
                     }
                 });
@@ -65,10 +64,10 @@ where
                 // Forward to remote sequencer RPC synchronously
                 match client.forward_raw_transaction(&tx).await {
                     Ok(sequencer_hash) => {
-                        tracing::debug!(target: "scroll::rpc::eth", local_hash=%hash, sequencer_hash=%sequencer_hash, "successfully forwarded transaction to sequencer");
+                        tracing::debug!(target: "scroll::rpc::eth", local_hash=%hash, %sequencer_hash, "successfully forwarded transaction to sequencer");
                     }
                     Err(err) => {
-                        tracing::warn!(target: "scroll::rpc::eth", %err, %hash, "failed to forward transaction to sequencer");
+                        tracing::warn!(target: "scroll::rpc::eth", %err, local_hash=%hash, "failed to forward transaction to sequencer");
                         return Err(ScrollEthApiError::Sequencer(err));
                     }
                 }


### PR DESCRIPTION
This PR makes tx forwarding non-blocking if the tx propagation is enabled. If the tx propagation is disabled (private mempool mode) then the forwarding is done synchronously to notify the user. In the additional case this is not necessary as it is optional and in the failure case the transaction will simply be broadcast like usual via gossip (public mempool).

Corresponding l2geth PR: https://github.com/scroll-tech/go-ethereum/pull/1227