### PR TITLE
feat: use `from_custom_genesis` for custom genesis files and set Scroll fee parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12372,9 +12372,9 @@ checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"

--- a/crates/scroll/chainspec/src/lib.rs
+++ b/crates/scroll/chainspec/src/lib.rs
@@ -8,20 +8,21 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use alloc::{boxed::Box, vec::Vec};
+use alloc::{boxed::Box, vec, vec::Vec};
 use alloy_chains::Chain;
 use alloy_consensus::Header;
 use alloy_genesis::Genesis;
 use alloy_primitives::{B256, U256};
 use derive_more::{Constructor, Deref, From, Into};
 use reth_chainspec::{
-    BaseFeeParams, ChainSpec, ChainSpecBuilder, DepositContract, EthChainSpec,
+    BaseFeeParams, BaseFeeParamsKind, ChainSpec, ChainSpecBuilder, DepositContract, EthChainSpec,
     EthereumCapabilities, EthereumHardforks, ForkFilter, ForkId, Hardforks, Head,
 };
 use reth_ethereum_forks::{
     ChainHardforks, EthereumHardfork, ForkCondition, ForkFilterKey, ForkHash, Hardfork,
 };
 use reth_network_peers::NodeRecord;
+use reth_primitives_traits::SealedHeader;
 use scroll_alloy_hardforks::{ScrollHardfork, ScrollHardforks};
 
 use alloy_eips::eip7840::BlobParams;
@@ -181,6 +182,39 @@ impl ScrollChainSpecBuilder {
     /// [`Self::genesis`])
     pub fn build(self, config: ScrollChainConfig) -> ScrollChainSpec {
         ScrollChainSpec { inner: self.inner.build(), config }
+    }
+}
+
+// Used by the CLI for custom genesis files.
+impl ScrollChainSpec {
+    /// Build from a custom `Genesis`, ensuring:
+    /// - `genesis_header` has `base_fee_per_gas` (0 if Feynman@genesis)
+    /// - `base_fee_params` switch to Scroll defaults at Feynman
+    pub fn from_custom_genesis(genesis: Genesis) -> Self {
+        // Use the existing From<Genesis> as the base.
+        let mut spec: Self = genesis.into();
+
+        // Determine whether Feynman is active at genesis.
+        let scroll_info = ScrollConfigInfo::extract_from(&spec.inner.genesis);
+        let feynman_active_at_genesis = scroll_info
+            .scroll_chain_info
+            .hard_fork_info
+            .and_then(|h| h.feynman_time)
+            .map(|t| t <= spec.inner.genesis.timestamp)
+            .unwrap_or(false);
+
+        // Ensure the genesis header has a base fee when required.
+        let mut header = make_genesis_header(&spec.inner.genesis);
+        if header.base_fee_per_gas.is_none() && feynman_active_at_genesis {
+            header.base_fee_per_gas = Some(0);
+        }
+        spec.inner.genesis_header = SealedHeader::new_unhashed(header);
+
+        // Use Scroll's EIP-1559 params from Feynman onwards.
+        spec.inner.base_fee_params = BaseFeeParamsKind::Variable(
+            vec![(ScrollHardfork::Feynman.boxed(), SCROLL_BASE_FEE_PARAMS_FEYNMAN)].into(),
+        );
+        spec
     }
 }
 

--- a/crates/scroll/chainspec/src/lib.rs
+++ b/crates/scroll/chainspec/src/lib.rs
@@ -195,13 +195,8 @@ impl ScrollChainSpec {
         let mut spec: Self = genesis.into();
 
         // Determine whether Feynman is active at genesis.
-        let scroll_info = ScrollConfigInfo::extract_from(&spec.inner.genesis);
-        let feynman_active_at_genesis = scroll_info
-            .scroll_chain_info
-            .hard_fork_info
-            .and_then(|h| h.feynman_time)
-            .map(|t| t <= spec.inner.genesis.timestamp)
-            .unwrap_or(false);
+        let feynman_active_at_genesis =
+            spec.is_feynman_active_at_timestamp(spec.inner.genesis.timestamp);
 
         // Ensure the genesis header has a base fee when required.
         let mut header = make_genesis_header(&spec.inner.genesis);

--- a/crates/scroll/cli/src/spec.rs
+++ b/crates/scroll/cli/src/spec.rs
@@ -15,7 +15,7 @@ impl ChainSpecParser for ScrollChainSpecParser {
             "dev" => SCROLL_DEV.clone(),
             "scroll-mainnet" => SCROLL_MAINNET.clone(),
             "scroll-sepolia" => SCROLL_SEPOLIA.clone(),
-            _ => Arc::new(parse_genesis(s)?.into()),
+            _ => Arc::new(ScrollChainSpec::from_custom_genesis(parse_genesis(s)?)),
         })
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -62,7 +62,6 @@ exceptions = [
     # TODO: decide on MPL-2.0 handling
     # These dependencies are grandfathered in https://github.com/paradigmxyz/reth/pull/6980
     { allow = ["MPL-2.0"], name = "option-ext" },
-    { allow = ["MPL-2.0"], name = "webpki-root-certs" },
 ]
 
 # Skip the poseidon-bn254, bn254 and zktrie crates for license verification. We should at some point publish a license for them.


### PR DESCRIPTION
If `Feynman` is active at genesis and `base_fee_per_gas` is missing, set it to 0 in the genesis header. Part of: https://github.com/scroll-tech/rollup-node/issues/217.