### PR TITLE
feat: async header response transform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8846,6 +8846,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
+ "async-trait",
  "auto_impl",
  "codspeed-criterion-compat",
  "derive_more",

--- a/crates/net/network/Cargo.toml
+++ b/crates/net/network/Cargo.toml
@@ -60,6 +60,7 @@ reth-metrics = { workspace = true, features = ["common"] }
 metrics.workspace = true
 
 # misc
+async-trait.workspace = true
 auto_impl.workspace = true
 aquamarine.workspace = true
 tracing.workspace = true

--- a/crates/net/network/src/builder.rs
+++ b/crates/net/network/src/builder.rs
@@ -9,12 +9,13 @@ use crate::{
         policy::NetworkPolicies,
         TransactionPropagationPolicy, TransactionsManager, TransactionsManagerConfig,
     },
-    transform::header::HeaderTransform,
+    transform::header::HeaderResponseTransform,
     NetworkHandle, NetworkManager,
 };
 use reth_eth_wire::{EthNetworkPrimitives, NetworkPrimitives};
 use reth_network_api::test_utils::PeersHandleProvider;
 use reth_transaction_pool::TransactionPool;
+use std::sync::Arc;
 use tokio::sync::mpsc;
 
 /// We set the max channel capacity of the `EthRequestHandler` to 256
@@ -64,7 +65,7 @@ impl<Tx, Eth, N: NetworkPrimitives> NetworkBuilder<Tx, Eth, N> {
     pub fn request_handler<Client>(
         self,
         client: Client,
-        request_header_transform: Option<Box<dyn HeaderTransform<N::BlockHeader>>>,
+        request_header_transform: Option<Arc<dyn HeaderResponseTransform<N::BlockHeader>>>,
     ) -> NetworkBuilder<Tx, EthRequestHandler<Client, N>, N> {
         let Self { mut network, transactions, .. } = self;
         let (tx, rx) = mpsc::channel(ETH_REQUEST_CHANNEL_CAPACITY);

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     budget::DEFAULT_BUDGET_TRY_DRAIN_DOWNLOADERS, metered_poll_nested_stream_with_budget,
-    metrics::EthRequestHandlerMetrics, transform::header::HeaderTransform,
+    metrics::EthRequestHandlerMetrics, transform::header::HeaderResponseTransform,
 };
 use alloy_consensus::{BlockHeader, ReceiptWithBloom};
 use alloy_eips::BlockHashOrNumber;
@@ -20,6 +20,7 @@ use reth_storage_api::{BlockReader, HeaderProvider};
 use std::{
     future::Future,
     pin::Pin,
+    sync::Arc,
     task::{Context, Poll},
     time::Duration,
 };
@@ -54,7 +55,7 @@ pub const SOFT_RESPONSE_LIMIT: usize = 2 * 1024 * 1024;
 #[must_use = "Manager does nothing unless polled."]
 pub struct EthRequestHandler<C, N: NetworkPrimitives = EthNetworkPrimitives> {
     /// The client type that can interact with the chain.
-    client: C,
+    client: Arc<C>,
     /// Used for reporting peers.
     // TODO use to report spammers
     #[expect(dead_code)]
@@ -62,7 +63,7 @@ pub struct EthRequestHandler<C, N: NetworkPrimitives = EthNetworkPrimitives> {
     /// Incoming request from the [`NetworkManager`](crate::NetworkManager).
     incoming_requests: ReceiverStream<IncomingEthRequest<N>>,
     /// The header transform to apply to the headers before sending to peers.
-    header_transform: Option<Box<dyn HeaderTransform<N::BlockHeader>>>,
+    header_transform: Option<Arc<dyn HeaderResponseTransform<N::BlockHeader>>>,
     /// Metrics for the eth request handler.
     metrics: EthRequestHandlerMetrics,
 }
@@ -74,10 +75,10 @@ impl<C, N: NetworkPrimitives> EthRequestHandler<C, N> {
         client: C,
         peers: PeersHandle,
         incoming: Receiver<IncomingEthRequest<N>>,
-        header_transform: Option<Box<dyn HeaderTransform<N::BlockHeader>>>,
+        header_transform: Option<Arc<dyn HeaderResponseTransform<N::BlockHeader>>>,
     ) -> Self {
         Self {
-            client,
+            client: Arc::new(client),
             peers,
             incoming_requests: ReceiverStream::new(incoming),
             header_transform,
@@ -89,10 +90,14 @@ impl<C, N: NetworkPrimitives> EthRequestHandler<C, N> {
 impl<C, N> EthRequestHandler<C, N>
 where
     N: NetworkPrimitives,
-    C: BlockReader<Header = N::BlockHeader>,
+    C: BlockReader<Header = N::BlockHeader> + 'static,
 {
     /// Returns the list of requested headers
-    fn get_headers_response(&self, request: GetBlockHeaders) -> Vec<C::Header> {
+    async fn get_headers_response(
+        client: Arc<C>,
+        header_transform: Option<Arc<dyn HeaderResponseTransform<N::BlockHeader>>>,
+        request: GetBlockHeaders,
+    ) -> Vec<C::Header> {
         let GetBlockHeaders { start_block, limit, skip, direction } = request;
 
         let mut headers = Vec::new();
@@ -100,9 +105,7 @@ where
         let mut block: BlockHashOrNumber = match start_block {
             BlockHashOrNumber::Hash(start) => start.into(),
             BlockHashOrNumber::Number(num) => {
-                let Some(hash) = self.client.block_hash(num).unwrap_or_default() else {
-                    return headers
-                };
+                let Some(hash) = client.block_hash(num).unwrap_or_default() else { return headers };
                 hash.into()
             }
         };
@@ -111,7 +114,7 @@ where
         let mut total_bytes = 0;
 
         for _ in 0..limit {
-            if let Some(header) = self.client.header_by_hash_or_number(block).unwrap_or_default() {
+            if let Some(header) = client.header_by_hash_or_number(block).unwrap_or_default() {
                 let number = header.number();
                 let parent_hash = header.parent_hash();
 
@@ -153,8 +156,12 @@ where
         }
 
         // TODO: remove this once we deprecated l2geth
-        if let Some(ref header_transform) = self.header_transform {
-            headers = headers.into_iter().map(|h| header_transform.map(h)).collect()
+        if let Some(ref header_transform) = header_transform {
+            let mut out = Vec::with_capacity(headers.len());
+            for header in headers {
+                out.push(header_transform.map(header).await);
+            }
+            return out;
         }
 
         headers
@@ -165,10 +172,14 @@ where
         _peer_id: PeerId,
         request: GetBlockHeaders,
         response: oneshot::Sender<RequestResult<BlockHeaders<C::Header>>>,
-    ) {
+    ) -> impl Future<Output = ()> + 'static {
         self.metrics.eth_headers_requests_received_total.increment(1);
-        let headers = self.get_headers_response(request);
-        let _ = response.send(Ok(BlockHeaders(headers)));
+        let client = self.client.clone();
+        let header_transform = self.header_transform.clone();
+        async move {
+            let headers = Self::get_headers_response(client, header_transform, request).await;
+            let _ = response.send(Ok(BlockHeaders(headers)));
+        }
     }
 
     fn on_bodies_request(
@@ -267,7 +278,8 @@ where
     N: NetworkPrimitives,
     C: BlockReader<Block = N::Block, Receipt = N::Receipt>
         + HeaderProvider<Header = N::BlockHeader>
-        + Unpin,
+        + Unpin
+        + 'static,
 {
     type Output = ();
 
@@ -284,7 +296,8 @@ where
             |incoming| {
                 match incoming {
                     IncomingEthRequest::GetBlockHeaders { peer_id, request, response } => {
-                        this.on_headers_request(peer_id, request, response)
+                        let future = this.on_headers_request(peer_id, request, response);
+                        tokio::spawn(future);
                     }
                     IncomingEthRequest::GetBlockBodies { peer_id, request, response } => {
                         this.on_bodies_request(peer_id, request, response)

--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -7,7 +7,7 @@ use crate::{
 use alloy_consensus::{BlockHeader, ReceiptWithBloom};
 use alloy_eips::BlockHashOrNumber;
 use alloy_rlp::Encodable;
-use futures::StreamExt;
+use futures::{future::join_all, StreamExt};
 use reth_eth_wire::{
     BlockBodies, BlockHeaders, EthNetworkPrimitives, GetBlockBodies, GetBlockHeaders, GetNodeData,
     GetReceipts, HeadersDirection, NetworkPrimitives, NodeData, Receipts, Receipts69,
@@ -157,11 +157,7 @@ where
 
         // TODO: remove this once we deprecated l2geth
         if let Some(ref header_transform) = header_transform {
-            let mut out = Vec::with_capacity(headers.len());
-            for header in headers {
-                out.push(header_transform.map(header).await);
-            }
-            return out;
+            return join_all(headers.into_iter().map(|h| header_transform.map(h))).await;
         }
 
         headers

--- a/crates/net/network/src/transform/header.rs
+++ b/crates/net/network/src/transform/header.rs
@@ -13,3 +13,18 @@ impl<H: BlockHeader> HeaderTransform<H> for () {
         header
     }
 }
+
+/// An instance of the trait applies a mapping to headers that are being sent to a peer in response
+/// to a request.
+#[async_trait::async_trait]
+pub trait HeaderResponseTransform<H: BlockHeader>: std::fmt::Debug + Send + Sync {
+    /// Applies a mapping to the response headers.
+    async fn map(&self, header: H) -> H;
+}
+
+#[async_trait::async_trait]
+impl<H: BlockHeader> HeaderResponseTransform<H> for () {
+    async fn map(&self, header: H) -> H {
+        header
+    }
+}

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -17,7 +17,7 @@ use reth_db_api::{database::Database, database_metrics::DatabaseMetrics};
 use reth_exex::ExExContext;
 use reth_network::{
     transactions::{TransactionPropagationPolicy, TransactionsManagerConfig},
-    transform::header::HeaderTransform,
+    transform::header::HeaderResponseTransform,
     NetworkBuilder, NetworkConfig, NetworkConfigBuilder, NetworkHandle, NetworkManager,
     NetworkPrimitives,
 };
@@ -586,10 +586,10 @@ where
     ///     .extend_rpc_modules(|ctx| {
     ///         // Access node components, so they can used by the CustomApi
     ///         let pool = ctx.pool().clone();
-    ///         
+    ///
     ///         // Add custom RPC namespace
     ///         ctx.modules.merge_configured(CustomApi { pool }.into_rpc())?;
-    ///         
+    ///
     ///         Ok(())
     ///     })
     ///     .build()?;
@@ -790,7 +790,7 @@ impl<Node: FullNodeTypes> BuilderContext<Node> {
         &self,
         builder: NetworkBuilder<(), (), N>,
         pool: Pool,
-        request_transform: Option<Box<dyn HeaderTransform<N::BlockHeader>>>,
+        request_transform: Option<Arc<dyn HeaderResponseTransform<N::BlockHeader>>>,
     ) -> NetworkHandle<N>
     where
         N: NetworkPrimitives,
@@ -824,7 +824,7 @@ impl<Node: FullNodeTypes> BuilderContext<Node> {
         pool: Pool,
         tx_config: TransactionsManagerConfig,
         propagation_policy: Policy,
-        request_transform: Option<Box<dyn HeaderTransform<N::BlockHeader>>>,
+        request_transform: Option<Arc<dyn HeaderResponseTransform<N::BlockHeader>>>,
     ) -> NetworkHandle<N>
     where
         N: NetworkPrimitives,

--- a/crates/optimism/consensus/src/proof.rs
+++ b/crates/optimism/consensus/src/proof.rs
@@ -118,7 +118,7 @@ mod tests {
         ];
 
         for case in cases {
-            let receipts = vec![
+            let receipts = [
                 // 0xb0d6ee650637911394396d81172bd1c637d568ed1fbddab0daddfca399c58b53
                 OpReceipt::Deposit(OpDepositReceipt {
                         inner: Receipt {

--- a/crates/payload/basic/src/lib.rs
+++ b/crates/payload/basic/src/lib.rs
@@ -852,10 +852,12 @@ pub trait PayloadBuilder: Send + Sync + Clone {
 /// Tells the payload builder how to react to payload request if there's no payload available yet.
 ///
 /// This situation can occur if the CL requests a payload before the first payload has been built.
+#[derive(Default)]
 pub enum MissingPayloadBehaviour<Payload> {
     /// Await the regular scheduled payload process.
     AwaitInProgress,
     /// Race the in progress payload process with an empty payload.
+    #[default]
     RaceEmptyPayload,
     /// Race the in progress payload process with this job.
     RacePayload(Box<dyn FnOnce() -> Result<Payload, PayloadBuilderError> + Send>),
@@ -870,12 +872,6 @@ impl<Payload> fmt::Debug for MissingPayloadBehaviour<Payload> {
             }
             Self::RacePayload(_) => write!(f, "RacePayload"),
         }
-    }
-}
-
-impl<Payload> Default for MissingPayloadBehaviour<Payload> {
-    fn default() -> Self {
-        Self::RaceEmptyPayload
     }
 }
 

--- a/crates/prune/types/src/mode.rs
+++ b/crates/prune/types/src/mode.rs
@@ -8,20 +8,15 @@ use alloy_primitives::BlockNumber;
 #[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
 #[cfg_attr(any(test, feature = "serde"), derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(any(test, feature = "serde"), serde(rename_all = "lowercase"))]
+#[cfg_attr(any(test, feature = "test-utils"), derive(Default))]
 pub enum PruneMode {
     /// Prune all blocks.
+    #[cfg_attr(any(test, feature = "test-utils"), default)]
     Full,
     /// Prune blocks before the `head-N` block number. In other words, keep last N + 1 blocks.
     Distance(u64),
     /// Prune blocks before the specified block number. The specified block number is not pruned.
     Before(BlockNumber),
-}
-
-#[cfg(any(test, feature = "test-utils"))]
-impl Default for PruneMode {
-    fn default() -> Self {
-        Self::Full
-    }
 }
 
 impl PruneMode {

--- a/crates/prune/types/src/segment.rs
+++ b/crates/prune/types/src/segment.rs
@@ -8,8 +8,10 @@ use thiserror::Error;
 #[cfg_attr(any(test, feature = "reth-codec"), derive(reth_codecs::Compact))]
 #[cfg_attr(any(test, feature = "reth-codec"), reth_codecs::add_arbitrary_tests(compact))]
 #[cfg_attr(any(test, feature = "serde"), derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(test, derive(Default))]
 pub enum PruneSegment {
     /// Prune segment responsible for the `TransactionSenders` table.
+    #[cfg_attr(test, default)]
     SenderRecovery,
     /// Prune segment responsible for the `TransactionHashNumbers` table.
     TransactionLookup,
@@ -71,11 +73,4 @@ pub enum PruneSegmentError {
     /// Invalid configuration of a prune segment.
     #[error("the configuration provided for {0} is invalid")]
     Configuration(PruneSegment),
-}
-
-#[cfg(test)]
-impl Default for PruneSegment {
-    fn default() -> Self {
-        Self::SenderRecovery
-    }
 }

--- a/crates/storage/libmdbx-rs/src/flags.rs
+++ b/crates/storage/libmdbx-rs/src/flags.rs
@@ -2,11 +2,12 @@ use bitflags::bitflags;
 use ffi::*;
 
 /// MDBX sync mode
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub enum SyncMode {
     /// Default robust and durable sync mode.
     /// Metadata is written and flushed to disk after a data is written and flushed, which
     /// guarantees the integrity of the database in the event of a crash at any time.
+    #[default]
     Durable,
 
     /// Don't sync the meta-page after commit.
@@ -98,12 +99,6 @@ pub enum SyncMode {
     /// be very useful in scenarios where data durability is not required over a system failure
     /// (e.g for short-lived data), or if you can take such risk.
     UtterlyNoSync,
-}
-
-impl Default for SyncMode {
-    fn default() -> Self {
-        Self::Durable
-    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -748,7 +748,7 @@ mod tests {
 
         // the independent set is the roots of each of these tx chains, these are the highest
         // nonces for each sender
-        let expected_highest_nonces = vec![d[0].clone(), c[2].clone(), b[2].clone(), a[3].clone()]
+        let expected_highest_nonces = [d[0].clone(), c[2].clone(), b[2].clone(), a[3].clone()]
             .iter()
             .map(|tx| (tx.sender(), tx.nonce()))
             .collect::<HashSet<_>>();

--- a/crates/trie/sparse-parallel/src/trie.rs
+++ b/crates/trie/sparse-parallel/src/trie.rs
@@ -5653,7 +5653,7 @@ mod tests {
         //   0xXY: Leaf { key: 0xZ... }
 
         // Create leaves that will force multiple subtries
-        let leaves = vec![
+        let leaves = [
             ctx.create_test_leaf([0x0, 0x0, 0x1, 0x2], 1),
             ctx.create_test_leaf([0x0, 0x1, 0x3, 0x4], 2),
             ctx.create_test_leaf([0x0, 0x2, 0x5, 0x6], 3),


### PR DESCRIPTION
# Overview
This modifies the header response transform trait to be asynchrnous such that we can correctly fetch signatures from the database in the `rollup-node` [PR](https://github.com/scroll-tech/rollup-node/pull/267/files)