### PR TITLE
feat: add missing td to rpc header

### DIFF
--- a/crates/scroll/rpc/src/eth/block.rs
+++ b/crates/scroll/rpc/src/eth/block.rs
@@ -1,11 +1,15 @@
 //! Loads and formats Scroll block RPC response.
 
-use crate::{ScrollEthApi, ScrollEthApiError};
+use crate::{RpcBlockHeaderMut, ScrollEthApi, ScrollEthApiError};
+use std::future::Future;
 
-use reth_rpc_convert::RpcConvert;
+use alloy_consensus::BlockHeader;
+use alloy_eips::BlockId;
+use reth_provider::HeaderProvider;
+use reth_rpc_convert::{RpcConvert, RpcTypes};
 use reth_rpc_eth_api::{
     helpers::{EthBlocks, LoadBlock},
-    RpcNodeCore,
+    EthApiTypes, FromEthApiError, FullEthApiTypes, RpcBlock, RpcNodeCore,
 };
 use reth_rpc_eth_types::error::FromEvmError;
 
@@ -14,7 +18,35 @@ where
     N: RpcNodeCore,
     ScrollEthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = ScrollEthApiError>,
+    <<ScrollEthApi<N, Rpc> as EthApiTypes>::NetworkTypes as RpcTypes>::Header: RpcBlockHeaderMut,
 {
+    fn rpc_block(
+        &self,
+        block_id: BlockId,
+        full: bool,
+    ) -> impl Future<Output = Result<Option<RpcBlock<Self::NetworkTypes>>, Self::Error>> + Send
+    where
+        Self: FullEthApiTypes,
+    {
+        async move {
+            let Some(block) = self.recovered_block(block_id).await? else { return Ok(None) };
+
+            let td = self
+                .provider()
+                .header_td_by_number(block.number())
+                .map_err(Self::Error::from_eth_err)?;
+
+            let mut block = block.clone_into_rpc_block(
+                full.into(),
+                |tx, tx_info| self.tx_resp_builder().fill(tx, tx_info),
+                |header, size| self.tx_resp_builder().convert_header(header, size),
+            )?;
+
+            *block.header.total_difficulty_mut() = td;
+
+            Ok(Some(block))
+        }
+    }
 }
 
 impl<N, Rpc> LoadBlock for ScrollEthApi<N, Rpc>

--- a/crates/scroll/rpc/src/eth/block.rs
+++ b/crates/scroll/rpc/src/eth/block.rs
@@ -1,7 +1,6 @@
 //! Loads and formats Scroll block RPC response.
 
 use crate::{RpcBlockHeaderMut, ScrollEthApi, ScrollEthApiError};
-use std::future::Future;
 
 use alloy_consensus::BlockHeader;
 use alloy_eips::BlockId;
@@ -18,34 +17,32 @@ where
     N: RpcNodeCore,
     ScrollEthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = ScrollEthApiError>,
-    <<ScrollEthApi<N, Rpc> as EthApiTypes>::NetworkTypes as RpcTypes>::Header: RpcBlockHeaderMut,
+    <<Self as EthApiTypes>::NetworkTypes as RpcTypes>::Header: RpcBlockHeaderMut,
 {
-    fn rpc_block(
+    async fn rpc_block(
         &self,
         block_id: BlockId,
         full: bool,
-    ) -> impl Future<Output = Result<Option<RpcBlock<Self::NetworkTypes>>, Self::Error>> + Send
+    ) -> Result<Option<RpcBlock<Self::NetworkTypes>>, Self::Error>
     where
         Self: FullEthApiTypes,
     {
-        async move {
-            let Some(block) = self.recovered_block(block_id).await? else { return Ok(None) };
+        let Some(block) = self.recovered_block(block_id).await? else { return Ok(None) };
 
-            let td = self
-                .provider()
-                .header_td_by_number(block.number())
-                .map_err(Self::Error::from_eth_err)?;
+        let td = self
+            .provider()
+            .header_td_by_number(block.number())
+            .map_err(Self::Error::from_eth_err)?;
 
-            let mut block = block.clone_into_rpc_block(
-                full.into(),
-                |tx, tx_info| self.tx_resp_builder().fill(tx, tx_info),
-                |header, size| self.tx_resp_builder().convert_header(header, size),
-            )?;
+        let mut block = block.clone_into_rpc_block(
+            full.into(),
+            |tx, tx_info| self.tx_resp_builder().fill(tx, tx_info),
+            |header, size| self.tx_resp_builder().convert_header(header, size),
+        )?;
 
-            *block.header.total_difficulty_mut() = td;
+        *block.header.total_difficulty_mut() = td;
 
-            Ok(Some(block))
-        }
+        Ok(Some(block))
     }
 }
 

--- a/crates/scroll/rpc/src/lib.rs
+++ b/crates/scroll/rpc/src/lib.rs
@@ -15,3 +15,15 @@ pub mod sequencer;
 pub use error::{ScrollEthApiError, SequencerClientError};
 pub use eth::{ScrollEthApi, ScrollReceiptBuilder};
 pub use sequencer::SequencerClient;
+
+/// Gives mutable access to the fields of an RPC block header.
+pub trait RpcBlockHeaderMut {
+    /// Mutable reference to the total difficulty.
+    fn total_difficulty_mut(&mut self) -> &mut Option<alloy_primitives::U256>;
+}
+
+impl RpcBlockHeaderMut for alloy_rpc_types_eth::Header {
+    fn total_difficulty_mut(&mut self) -> &mut Option<alloy_primitives::U256> {
+        &mut self.total_difficulty
+    }
+}


### PR DESCRIPTION
This PR reverts changes performed on this Reth [PR](https://github.com/paradigmxyz/reth/pull/13303) by implementing the `rpc_block` method for the `EthBlock` for `ScrollEthApi`, fetching the Td from provider and adding it to the header.

This what tested on Sepolia for a couple of blocks and returns the correct Td (see attached screenshots).

## Block 100
<img width="797" height="238" alt="Screenshot 2025-09-22 at 12 58 20" src="https://github.com/user-attachments/assets/10142f71-1bec-42af-99ee-c1ac2cd6c284" />

## Block 1259081
<img width="785" height="234" alt="Screenshot 2025-09-22 at 12 59 11" src="https://github.com/user-attachments/assets/95943035-7c89-4084-b40a-1e67709f9d74" />

## Block 12341932
<img width="800" height="228" alt="Screenshot 2025-09-22 at 12 58 28" src="https://github.com/user-attachments/assets/f6f7e704-1464-41eb-9426-a8701b9f60a1" />
