### PR TITLE
perf: skipping computing compression ratio for l1 messages

### DIFF
--- a/crates/scroll/alloy/evm/src/tx/mod.rs
+++ b/crates/scroll/alloy/evm/src/tx/mod.rs
@@ -161,8 +161,7 @@ impl FromTxWithEncoded<ScrollTxEnvelope> for ScrollTransactionIntoTxEnv<TxEnv> {
 
         let encoded = (!tx.is_l1_message()).then_some(encoded);
         // Note: We compute the transaction ratio on tx.data, not on the full encoded transaction.
-        let compression_ratio =
-            (!tx.is_l1_message()).then_some(compute_compression_ratio(base.input()));
+        let compression_ratio = (!tx.is_l1_message()).then(compute_compression_ratio(base.input()));
         Self::new(base, encoded, compression_ratio)
     }
 }
@@ -271,8 +270,7 @@ impl FromRecoveredTx<ScrollTxEnvelope> for ScrollTransactionIntoTxEnv<TxEnv> {
 
         let encoded = (!tx.is_l1_message()).then_some(envelope.into());
         // Note: We compute the transaction ratio on tx.data, not on the full encoded transaction.
-        let compression_ratio =
-            (!tx.is_l1_message()).then_some(compute_compression_ratio(base.input()));
+        let compression_ratio = (!tx.is_l1_message()).then(compute_compression_ratio(base.input()));
 
         Self::new(base, encoded, compression_ratio)
     }

--- a/crates/scroll/alloy/evm/src/tx/mod.rs
+++ b/crates/scroll/alloy/evm/src/tx/mod.rs
@@ -161,8 +161,9 @@ impl FromTxWithEncoded<ScrollTxEnvelope> for ScrollTransactionIntoTxEnv<TxEnv> {
 
         let encoded = (!tx.is_l1_message()).then_some(encoded);
         // Note: We compute the transaction ratio on tx.data, not on the full encoded transaction.
-        let compression_ratio = compute_compression_ratio(base.input());
-        Self::new(base, encoded, Some(compression_ratio))
+        let compression_ratio =
+            (!tx.is_l1_message()).then_some(compute_compression_ratio(base.input()));
+        Self::new(base, encoded, compression_ratio)
     }
 }
 
@@ -270,7 +271,9 @@ impl FromRecoveredTx<ScrollTxEnvelope> for ScrollTransactionIntoTxEnv<TxEnv> {
 
         let encoded = (!tx.is_l1_message()).then_some(envelope.into());
         // Note: We compute the transaction ratio on tx.data, not on the full encoded transaction.
-        let compression_ratio = compute_compression_ratio(base.input());
-        Self::new(base, encoded, Some(compression_ratio))
+        let compression_ratio =
+            (!tx.is_l1_message()).then_some(compute_compression_ratio(base.input()));
+
+        Self::new(base, encoded, compression_ratio)
     }
 }

--- a/crates/scroll/alloy/evm/src/tx/mod.rs
+++ b/crates/scroll/alloy/evm/src/tx/mod.rs
@@ -161,7 +161,8 @@ impl FromTxWithEncoded<ScrollTxEnvelope> for ScrollTransactionIntoTxEnv<TxEnv> {
 
         let encoded = (!tx.is_l1_message()).then_some(encoded);
         // Note: We compute the transaction ratio on tx.data, not on the full encoded transaction.
-        let compression_ratio = (!tx.is_l1_message()).then(compute_compression_ratio(base.input()));
+        let compression_ratio =
+            (!tx.is_l1_message()).then(|| compute_compression_ratio(base.input()));
         Self::new(base, encoded, compression_ratio)
     }
 }
@@ -270,7 +271,8 @@ impl FromRecoveredTx<ScrollTxEnvelope> for ScrollTransactionIntoTxEnv<TxEnv> {
 
         let encoded = (!tx.is_l1_message()).then_some(envelope.into());
         // Note: We compute the transaction ratio on tx.data, not on the full encoded transaction.
-        let compression_ratio = (!tx.is_l1_message()).then(compute_compression_ratio(base.input()));
+        let compression_ratio =
+            (!tx.is_l1_message()).then(|| compute_compression_ratio(base.input()));
 
         Self::new(base, encoded, compression_ratio)
     }


### PR DESCRIPTION
As per the Issue #344, Computing compression ratio is skipped for L1 messages. 