### PR TITLE
feat: async header transform

### DIFF
--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -99,7 +99,7 @@ pub struct NetworkConfig<C, N: NetworkPrimitives = EthNetworkPrimitives> {
     /// If non-empty, peers that don't have these blocks will be filtered out.
     pub required_block_hashes: Vec<B256>,
     /// A transformation hook applied to the downloaded headers.
-    pub header_transform: Box<dyn HeaderTransform<N::BlockHeader>>,
+    pub header_transform: Arc<dyn HeaderTransform<N::BlockHeader>>,
 }
 
 // === impl NetworkConfig ===
@@ -232,7 +232,7 @@ pub struct NetworkConfigBuilder<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// Optional network id
     network_id: Option<u64>,
     /// The header transform type.
-    header_transform: Option<Box<dyn HeaderTransform<N::BlockHeader>>>,
+    header_transform: Option<Arc<dyn HeaderTransform<N::BlockHeader>>>,
 }
 
 impl NetworkConfigBuilder<EthNetworkPrimitives> {
@@ -605,7 +605,7 @@ impl<N: NetworkPrimitives> NetworkConfigBuilder<N> {
     /// Sets the header transform type.
     pub fn header_transform(
         mut self,
-        header_transform: Box<dyn HeaderTransform<N::BlockHeader>>,
+        header_transform: Arc<dyn HeaderTransform<N::BlockHeader>>,
     ) -> Self {
         self.header_transform = Some(header_transform);
         self
@@ -717,7 +717,7 @@ impl<N: NetworkPrimitives> NetworkConfigBuilder<N> {
             nat,
             handshake,
             required_block_hashes,
-            header_transform: header_transform.unwrap_or_else(|| Box::new(())),
+            header_transform: header_transform.unwrap_or_else(|| Arc::new(())),
         }
     }
 }

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -6,7 +6,7 @@ pub use client::FetchClient;
 
 use crate::{message::BlockRequest, session::BlockRangeInfo, transform::header::HeaderTransform};
 use alloy_primitives::B256;
-use futures::StreamExt;
+use futures::{future::join_all, StreamExt};
 use reth_eth_wire::{EthNetworkPrimitives, GetBlockBodies, GetBlockHeaders, NetworkPrimitives};
 use reth_network_api::test_utils::PeersHandle;
 use reth_network_p2p::{
@@ -283,12 +283,7 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
             tokio::spawn(async move {
                 let res = match res {
                     Ok(headers) => {
-                        let mut transformed_headers = Vec::with_capacity(headers.len());
-                        for header in headers {
-                            let transformed = header_transform.map(header).await;
-                            transformed_headers.push(transformed);
-                        }
-                        Ok(transformed_headers)
+                        Ok(join_all(headers.into_iter().map(|h| header_transform.map(h))).await)
                     }
                     Err(e) => Err(e),
                 };

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -6,7 +6,7 @@ pub use client::FetchClient;
 
 use crate::{message::BlockRequest, session::BlockRangeInfo, transform::header::HeaderTransform};
 use alloy_primitives::B256;
-use futures::{future::join_all, StreamExt};
+use futures::StreamExt;
 use reth_eth_wire::{EthNetworkPrimitives, GetBlockBodies, GetBlockHeaders, NetworkPrimitives};
 use reth_network_api::test_utils::PeersHandle;
 use reth_network_p2p::{
@@ -282,9 +282,7 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
             let header_transform = self.header_transform.clone();
             tokio::spawn(async move {
                 let res = match res {
-                    Ok(headers) => {
-                        Ok(join_all(headers.into_iter().map(|h| header_transform.map(h))).await)
-                    }
+                    Ok(headers) => Ok(header_transform.map(headers).await),
                     Err(e) => Err(e),
                 };
 

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -56,7 +56,7 @@ pub struct StateFetcher<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// Sender for download requests, used to detach a [`FetchClient`]
     download_requests_tx: UnboundedSender<DownloadRequest<N>>,
     /// A transformation hook applied to the downloaded headers.
-    header_transform: Box<dyn HeaderTransform<N::BlockHeader>>,
+    header_transform: Arc<dyn HeaderTransform<N::BlockHeader>>,
 }
 
 // === impl StateSyncer ===
@@ -65,7 +65,7 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
     pub(crate) fn new(
         peers_handle: PeersHandle,
         num_active_peers: Arc<AtomicUsize>,
-        header_transform: Box<dyn HeaderTransform<N::BlockHeader>>,
+        header_transform: Arc<dyn HeaderTransform<N::BlockHeader>>,
     ) -> Self {
         let (download_requests_tx, download_requests_rx) = mpsc::unbounded_channel();
         Self {
@@ -279,10 +279,22 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
             resp.as_ref().is_some_and(|r| res.is_likely_bad_headers_response(&r.request));
 
         if let Some(resp) = resp {
-            // apply the header transform and delegate the response
-            let _ = resp.response.send(res.map(|h| {
-                (peer_id, h.into_iter().map(|h| self.header_transform.map(h)).collect()).into()
-            }));
+            let header_transform = self.header_transform.clone();
+            tokio::spawn(async move {
+                let res = match res {
+                    Ok(headers) => {
+                        let mut transformed_headers = Vec::with_capacity(headers.len());
+                        for header in headers {
+                            let transformed = header_transform.map(header).await;
+                            transformed_headers.push(transformed);
+                        }
+                        Ok(transformed_headers)
+                    }
+                    Err(e) => Err(e),
+                };
+
+                let _ = resp.response.send(res.map(|h| (peer_id, h).into()));
+            });
         }
 
         if let Some(peer) = self.peers.get_mut(&peer_id) {
@@ -496,7 +508,7 @@ mod tests {
         let mut fetcher = StateFetcher::<EthNetworkPrimitives>::new(
             manager.handle(),
             Default::default(),
-            Box::new(()),
+            Arc::new(()),
         );
 
         poll_fn(move |cx| {
@@ -521,7 +533,7 @@ mod tests {
         let mut fetcher = StateFetcher::<EthNetworkPrimitives>::new(
             manager.handle(),
             Default::default(),
-            Box::new(()),
+            Arc::new(()),
         );
         // Add a few random peers
         let peer1 = B512::random();
@@ -548,7 +560,7 @@ mod tests {
         let mut fetcher = StateFetcher::<EthNetworkPrimitives>::new(
             manager.handle(),
             Default::default(),
-            Box::new(()),
+            Arc::new(()),
         );
         // Add a few random peers
         let peer1 = B512::random();
@@ -577,7 +589,7 @@ mod tests {
         let mut fetcher = StateFetcher::<EthNetworkPrimitives>::new(
             manager.handle(),
             Default::default(),
-            Box::new(()),
+            Arc::new(()),
         );
         let peer_id = B512::random();
 
@@ -611,7 +623,7 @@ mod tests {
         let mut fetcher = StateFetcher::<EthNetworkPrimitives>::new(
             manager.handle(),
             Default::default(),
-            Box::new(()),
+            Arc::new(()),
         );
         let peer_id = B512::random();
 

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -102,7 +102,7 @@ impl<N: NetworkPrimitives> NetworkState<N> {
         discovery: Discovery,
         peers_manager: PeersManager,
         num_active_peers: Arc<AtomicUsize>,
-        header_transform: Box<dyn HeaderTransform<N::BlockHeader>>,
+        header_transform: Arc<dyn HeaderTransform<N::BlockHeader>>,
     ) -> Self {
         let state_fetcher =
             StateFetcher::new(peers_manager.handle(), num_active_peers, header_transform);
@@ -582,7 +582,7 @@ mod tests {
             queued_messages: Default::default(),
             client: BlockNumReader(Box::new(NoopProvider::default())),
             discovery: Discovery::noop(),
-            state_fetcher: StateFetcher::new(handle, Default::default(), Box::new(())),
+            state_fetcher: StateFetcher::new(handle, Default::default(), Arc::new(())),
         }
     }
 

--- a/crates/net/network/src/transform/header.rs
+++ b/crates/net/network/src/transform/header.rs
@@ -3,13 +3,15 @@
 use reth_primitives_traits::BlockHeader;
 
 /// An instance of the trait applies a mapping to the input header.
+#[async_trait::async_trait]
 pub trait HeaderTransform<H: BlockHeader>: std::fmt::Debug + Send + Sync {
     /// Applies a mapping to the input header.
-    fn map(&self, header: H) -> H;
+    async fn map(&self, header: H) -> H;
 }
 
+#[async_trait::async_trait]
 impl<H: BlockHeader> HeaderTransform<H> for () {
-    fn map(&self, header: H) -> H {
+    async fn map(&self, header: H) -> H {
         header
     }
 }

--- a/crates/net/network/src/transform/header.rs
+++ b/crates/net/network/src/transform/header.rs
@@ -2,17 +2,17 @@
 
 use reth_primitives_traits::BlockHeader;
 
-/// An instance of the trait applies a mapping to the input header.
+/// An instance of the trait applies a mapping to the input headers.
 #[async_trait::async_trait]
 pub trait HeaderTransform<H: BlockHeader>: std::fmt::Debug + Send + Sync {
-    /// Applies a mapping to the input header.
-    async fn map(&self, header: H) -> H;
+    /// Applies a mapping to the input headers.
+    async fn map(&self, headers: Vec<H>) -> Vec<H>;
 }
 
 #[async_trait::async_trait]
 impl<H: BlockHeader> HeaderTransform<H> for () {
-    async fn map(&self, header: H) -> H {
-        header
+    async fn map(&self, headers: Vec<H>) -> Vec<H> {
+        headers
     }
 }
 


### PR DESCRIPTION
# Overview
Previously, the `map` method on the `HeaderTransform` trait was synchronous. To work around this constraint in the `rollup-node` we would spawn a new background task to insert the signatures into the database. However, this resulted in an unbounded number of tokio tasks responsible for inserting singatures into the database being spawned. In this PR we make the map method `async` and `await` the result of the `map` method before we send the result to the client. This provides a natural backpressure on the system. 